### PR TITLE
#15 add v1 use cases to rest api

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -3164,6 +3164,11 @@
         "sshpk": "^1.7.0"
       }
     },
+    "http-status-codes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-1.4.0.tgz",
+      "integrity": "sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ=="
+    },
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -11,7 +11,8 @@
   "license": "ISC",
   "dependencies": {
     "fastify": "^2.14.1",
-    "fluent-schema": "^1.0.3"
+    "fluent-schema": "^1.0.3",
+    "http-status-codes": "^1.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.3",

--- a/api/src/handlers.js
+++ b/api/src/handlers.js
@@ -2,12 +2,11 @@ import schemas from "./schemas";
 
 import appData from "../package.json";
 import testData from "../data.json";
+import * as HttpStatus from 'http-status-codes'
 
 import {
   FindInvalidQueryParams,
 } from './queryHelpers';
-
-var HttpStatus = require('http-status-codes');
 
 const ITEMS_PARAM_WHITELIST = [
   'code',

--- a/api/src/handlers.js
+++ b/api/src/handlers.js
@@ -3,10 +3,21 @@ import schemas from "./schemas";
 import appData from "../package.json";
 import testData from "../data.json";
 
-const STATUS_CODES = {
-  OK: 200,
-  NOT_FOUND: 404,
-}
+import {
+  FindInvalidQueryParams,
+} from './queryHelpers';
+
+var HttpStatus = require('http-status-codes');
+
+const ITEMS_PARAM_WHITELIST = [
+  'code',
+  'exact',
+  'fields',
+  'fuzzy',
+  'inclusive',
+  'name',
+  'search',
+];
 
 const healthHandler = (_, reply) => {
   const [response] = Object.values(schemas.health.response);
@@ -21,14 +32,21 @@ const healthHandler = (_, reply) => {
 const itemsHandler = (request, reply) => {
   const { query } = request;
   const { code } = query;
-  if (code) {
+
+  const badQueryParams = FindInvalidQueryParams(query, ITEMS_PARAM_WHITELIST);
+  if (badQueryParams.length) {
+    const statusCode = HttpStatus.BAD_REQUEST;
+    const body = `There are invalid query parameters in the request URL: '${String(badQueryParams)}'`
+    reply.code(statusCode).send(body);
+  }
+  else if (code) {
     const isValidCode = Object.keys(testData).includes(code);
-    const statusCode = isValidCode ? STATUS_CODES.OK : STATUS_CODES.NOT_FOUND;
+    const statusCode = isValidCode ? HttpStatus.OK : HttpStatus.NOT_FOUND;
     const body =
       isValidCode ? { code, name: testData[code] } : { error: `No item with code ${code}` };
     reply.code(statusCode).send(body);
   } else {
-    const statusCode = STATUS_CODES.OK;
+    const statusCode = HttpStatus.OK;
     const body = Object.entries(testData).map(([key, value]) => ({ code: key, name: value }));
     reply.code(statusCode).send(body);
   }

--- a/api/src/queryHelpers.js
+++ b/api/src/queryHelpers.js
@@ -1,0 +1,14 @@
+/**
+* InvalidQueryParams checks for incorrect query parameter(s)
+*
+* @param {obj}     queryParams - object of request URL query params (AWS)
+* @param {arr}     whiteList - array of allowed params; per implementation
+* @return {arr}    returns array of bad parameters, or empty array
+*/
+export const FindInvalidQueryParams = (queryParams, whiteList) => (
+    Object.keys(queryParams).filter(parameter => (
+      !whiteList.includes(parameter)
+    ))
+  );
+
+  

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -63,3 +63,16 @@ describe("Test version endpoint", () => {
         });
     });
 });
+
+describe("Test invalid endpoint", () => {
+    test("Invalid endpoint response has status code 404", done => {
+        api.inject({
+            method: 'GET',
+            url: '/invalid'
+        }).then(response => {
+            const { statusCode } = response;
+            expect(statusCode).toBe(404);
+            done();
+        });
+    });
+});

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -25,6 +25,18 @@ describe("Test items endpoint", () => {
         });
     });
 
+    test("Items endpoint with invalid params has status code 400", done => {
+        api.inject({
+            method: 'GET',
+            url: '/items',
+            query: ({ badQuery: 'invalidData' })
+        }).then(response => {
+            const { statusCode } = response;
+            expect(statusCode).toBe(400);
+            done();
+        });
+    });
+
 });
 
 describe("Test version endpoint", () => {


### PR DESCRIPTION
Partially fixes #15

Adding 2 additional test cases:
- Items endpoint with invalid params has status code 400 (with implementation ported over from v1 of the api)
- Invalid endpoint response has status code 404

Added https://www.npmjs.com/package/http-status-codes for response codes 