### PR TITLE
#14 expand rest api test data

### DIFF
--- a/dgraph/sample/data.json
+++ b/dgraph/sample/data.json
@@ -15,7 +15,13 @@
         },
         {
           "type": "drugbank_code",
-          "value": "DB01060"
+          "value": "DB01060",
+          "has_property": [
+            {
+              "type": "source",
+              "value": "https://drugbank.ca/drugs/" 
+            }
+          ]
         },
         {
           "type": "atc_code",
@@ -50,6 +56,12 @@
         {
           "description": "Amoxicillin oral",
           "type": "form_category",
+          "has_property": [
+            {
+                "value": "350162003",
+                "type": "SnoMED CT"
+            }
+          ],
           "has_child": [
             {
               "description": "Amoxicillin oral capsule",

--- a/dgraph/sample/data.json
+++ b/dgraph/sample/data.json
@@ -54,6 +54,7 @@
       ],
       "has_child": [
         {
+          "code": "AMOX0R47",
           "description": "Amoxicillin oral",
           "type": "form_category",
           "has_property": [
@@ -64,6 +65,7 @@
           ],
           "has_child": [
             {
+              "code": "AMOX0C4P",
               "description": "Amoxicillin oral capsule",
               "type": "form",
               "has_child": [

--- a/dgraph/sample/data.json
+++ b/dgraph/sample/data.json
@@ -14,23 +14,207 @@
           "value": "6.2.1 Beta-lactam medicines"
         },
         {
-          "type": "unspc_code",
-          "value": "51281712"
-        },
-        {
-          "type": "usfda_code",
-          "value": "544Y3K6MYH"
-        },
-        {
           "type": "drugbank_code",
           "value": "DB01060"
         },
         {
           "type": "atc_code",
           "value": "J01CA04"
+        },
+        {
+          "type": "synonym",
+          "value": "Amoxicillin Anhydrous"
+        },
+        {
+          "type": "synonym",
+          "value": "Amoxicillin trihydrate",
+          "has_property": [
+            {
+              "type": "unspc_code",
+              "value": "51281712"
+            }
+          ]
+        },
+        {
+          "type": "synonym",
+          "value": "Amoxicillin sodium",
+          "has_property": [
+            {
+              "type": "usfda_code",
+              "value": "544Y3K6MYH"
+            }
+          ]
         }
       ],
-      "has_child": []
+      "has_child": [
+        {
+          "description": "Amoxicillin oral",
+          "type": "form_category",
+          "has_child": [
+            {
+              "description": "Amoxicillin oral capsule",
+              "type": "form",
+              "has_child": [
+                {
+                  "description": "Amoxicillin oral capsule, 250mg",
+                  "code": "368C74BF",
+                  "type": "unit_of_use",
+                  "has_property": [
+                    {
+                      "type": "RxNorm RxCUI",
+                      "value": "308182"
+                    },
+                    {
+                      "type": "ddd_factor",
+                      "value": "4"
+                    }
+                  ],
+                  "has_child": [
+                    {
+                      "code": "DF2947SK",
+                      "type": "product_pack",
+                      "description": "Amoxicillin oral capsule, 250mg x 30",
+                      "has_property": [
+                        {
+                          "type": "pack_size",
+                          "value": "30",
+                          "has_property": [
+                            {
+                              "type": "brand",
+                              "value": "Wymox",
+                              "has_property": [
+                                {
+                                  "type": "manufacturer",
+                                  "value": "Pfizer Ltd"
+                                },
+                                {
+                                  "type": "GS1",
+                                  "value": "294719487329872"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "brand",
+                              "value": "Almox",
+                              "has_property": [
+                                {
+                                  "type": "manufacturer",
+                                  "value": "Alkem Laboratories Ltd"
+                                },
+                                {
+                                  "type": "GS1",
+                                  "value": "294719487329872"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "usd_benchmark_price",
+                          "value": "0.0235"
+                        }
+                      ]
+                    },
+                    {
+                      "code": "DF2947TL",
+                      "type": "product_pack",
+                      "description": "Amoxicillin oral capsule, 250mg x 100",
+                      "has_property": [
+                        {
+                          "type": "pack_size",
+                          "value": "100",
+                          "has_property": [
+                            {
+                              "type": "brand",
+                              "value": "Ambionica",
+                              "has_property": [
+                                {
+                                  "type": "GS1",
+                                  "value": "294719487329872"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "brand",
+                              "value": "Amofix",
+                              "has_property": [
+                                {
+                                  "type": "GS1",
+                                  "value": "24329472982347"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "usd_benchmark_price",
+                          "value": "0.0235"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "description": "Amoxicillin oral tablet",
+              "type": "form",
+              "has_child" : [
+                {
+                  "code": "368C74BE",
+                  "type": "unit_of_use",
+                  "description": "Amoxicillin oral tablet 500mg",
+                  "has_property": [
+                    {
+                      "type": "strength",
+                      "value": "500mg"
+                    },
+                    {
+                      "type": "RxNorm RxCUI",
+                      "value": "C0974350"
+                    },
+                    {
+                      "type": "ddd_factor",
+                      "value": "2"
+                    }
+                  ],
+                  "has_child": [
+                    {
+                      "code": "DF2947SL",
+                      "type": "product_pack",
+                      "description": "Amoxicillin oral tablet 500mg x 100",
+                      "has_property": [
+                        {
+                          "type": "pack_size",
+                          "value": "100"
+                        },
+                        {
+                          "type": "brand",
+                          "value": "Trimox",
+                          "has_property": [
+                            {
+                              "type": "manufacturer",
+                              "value": "Mapra Laboratories Pvt Ltd"
+                            },
+                            {
+                              "type": "GS1",
+                              "value": "294719487329856"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "usd_benchmark_price",
+                          "value": "0.88"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     },
     {
       "description": "Paracetamol",

--- a/dgraph/sample/data.rdf
+++ b/dgraph/sample/data.rdf
@@ -56,8 +56,10 @@
         _:unitOfUse1 <type> "unit_of_use" .
         _:unitOfUse1 <code> "368C74BF" .
         _:pack1 <description> "Amoxicillin oral capsule 250mg x 30" .
-        _:pack1 <type> "pack_size" .
+        _:pack1 <type> "product_pack" .
         _:pack1 <code> "DF2947SK" .
+        _:packSize1 <type> "pack_size" .
+        _:packSize1 <code> "30" .
 
         _:prod1 <has_property> _:value1 .
         _:prod1 <has_property> _:prop1 .
@@ -78,6 +80,7 @@
         _:unitOfUse1 <has_property> _:prop10 .
         _:unitOfUse1 <has_child> _:pack1 .
 
+        _:pack1 <has_property> _:packSize1 .
         _:pack1 <has_property> _:prop11 .
         _:pack1 <has_property> _:brand1 .
         _:pack1 <has_property> _:brand2 .

--- a/dgraph/sample/data.rdf
+++ b/dgraph/sample/data.rdf
@@ -47,9 +47,11 @@
         _:man2 <value> "Pfizer Ltd" .
         _:man2 <type> "manufacturer" .
 
+        _:formcat1 <code> "AMOX0R47" .
         _:formcat1 <description> "Amoxicillin oral" .
         _:formcat1 <type> "form_category" .
 
+        _:form1 <code> "AMOX0C4P" .
         _:form1 <description> "Amoxicillin oral capsule" .
         _:form1 <type> "form" .
         _:unitOfUse1 <description> "Amoxicillin oral capsule 250mg" .

--- a/dgraph/sample/data.rdf
+++ b/dgraph/sample/data.rdf
@@ -29,6 +29,10 @@
         _:prop10 <type> "ddd_factor" .
         _:prop11 <value> "0.0235" .
         _:prop11 <type> "usd_benchmark_price" .
+        _:prop12 <value> "350162003" .
+        _:prop12 <type> "SnoMED CT" .
+        _:prop13 <value> "https://drugbank.ca/drugs/" .
+        _:prop13 <type> "source" .
 
         _:brand1 <value> "Almox" .
         _:brand1 <type> "brand" .
@@ -43,16 +47,16 @@
         _:man2 <value> "Pfizer Ltd" .
         _:man2 <type> "manufacturer" .
 
-        _:formcat1 <description> "Oral dose forms" .
+        _:formcat1 <description> "Amoxicillin oral" .
         _:formcat1 <type> "form_category" .
 
-        _:form1 <description> "Capsule" .
+        _:form1 <description> "Amoxicillin oral capsule" .
         _:form1 <type> "form" .
-        _:strength1 <value> "250mg" .
-        _:strength1 <type> "strength" .
-        _:strength1 <code> "368C74BF" .
-        _:pack1 <value> "30" .
-        _:pack1 <type> "pack" .
+        _:unitOfUse1 <description> "Amoxicillin oral capsule 250mg" .
+        _:unitOfUse1 <type> "unit_of_use" .
+        _:unitOfUse1 <code> "368C74BF" .
+        _:pack1 <description> "Amoxicillin oral capsule 250mg x 30" .
+        _:pack1 <type> "pack_size" .
         _:pack1 <code> "DF2947SK" .
 
         _:prod1 <has_property> _:value1 .
@@ -64,13 +68,15 @@
         _:prod1 <has_property> _:prop6 .
         _:prop4 <has_property> _:prop7 .
         _:prop5 <has_property> _:prop8 .
+        _:prop6 <has_property> _:prop13 .
 
-        _:prod1 <has_property> _:formcat1 .
-        _:formcat1 <has_property> _:form1 .
-        _:form1 <has_child> _:strength1 .
-        _:strength1 <has_property> _:prop9 .
-        _:strength1 <has_property> _:prop10 .
-        _:strength1 <has_child> _:pack1 .
+        _:prod1 <has_child> _:formcat1 .
+        _:formcat1 <has_child> _:form1 .
+        _:formcat1 <has_property> _:prop12 .
+        _:form1 <has_child> _:unitOfUse1 .
+        _:unitOfUse1 <has_property> _:prop9 .
+        _:unitOfUse1 <has_property> _:prop10 .
+        _:unitOfUse1 <has_child> _:pack1 .
 
         _:pack1 <has_property> _:prop11 .
         _:pack1 <has_property> _:brand1 .

--- a/dgraph/sample/schema.gql
+++ b/dgraph/sample/schema.gql
@@ -9,6 +9,7 @@ type Entity {
 type Property {
   type
   value
+  has_property 
 }
 
 code: string @index(exact, fulltext).


### PR DESCRIPTION
Fixes #14
 
Re-populated Amox example from [wiki](https://sussol.net/wiki/doku.php/msupply:planning:projects:universal_codes_v2) into sample data files.
- Added SnoMED CT and Drug Bank Url
- Added nested property to schema (the existing examples already had this, though it wasn't explicitly defined in schema)
- Align RDF with JSON

Possible next steps if all good with this schema:
- Add Paracetamol example to RDF
- More products
- More API test cases
- Add sample expected API results based on test data 