### PR TITLE
#27 add additional api test cases

### DIFF
--- a/api/src/handlers.js
+++ b/api/src/handlers.js
@@ -25,11 +25,10 @@ const itemsHandler = (request, reply) => {
     )}'`;
     reply.code(statusCode).send(body);
   } else {
-    const dgraphClient = new DgraphClient(
-      new DgraphClientStub('http://localhost:8080')
-    );
+    const dgraphClient = new DgraphClient(new DgraphClientStub('http://localhost:8080'));
     const txn = dgraphClient.newTxn();
-    txn.query(mapRequest(request)).then(response => {
+    const { query, vars } = mapRequest(request);
+    txn.queryWithVars(query, vars).then((response) => {
       reply.code(HTTP_OK).send(mapResponse(response));
     });
   }

--- a/api/src/mappers.js
+++ b/api/src/mappers.js
@@ -40,40 +40,11 @@ export const mapRequest = (request) => {
   const { query } = request;
   const { code, name } = query;
   const exact = parseBool(query.exact);
-
-  if (code) {
-    return `{
-      query(func: has(code)) @filter(eq(code, ${code}))
-      {	
-        code
-        description
-      }
-    }`;
-  } else if (name) {
-    if (exact) {
-      return `{
-        query(func: has(code)) @filter(eq(description, ${name}) AND eq(type, "unit_of_use")) {
-          code
-          description
-        }
-      }`;
-    } else {
-      return `{
-        query(func: has(code)) @filter(regexp(description, "^${name}.*$", "i") AND eq(type, "unit_of_use")) {
-          code
-          description
-        }
-      }`;
-    }
-  } else {
-    // Default to all unit of use entities
-    return `{
-      query(func: has(code)) @filter(eq(type, "unit_of_use")) {
-        code
-        description
-      }
-    }`;
-  }
+  if (code) return { query: itemQueries.get, vars: { $code: code } };
+  else if (name) {
+    if (exact) return { query: itemQueries.searchExact, vars: { $name: name } };
+    else return { query: itemQueries.search, vars: { $name: name } };
+  } else return { query: itemQueries.all, vars: {} };
 };
 
 /**

--- a/api/src/mappers.js
+++ b/api/src/mappers.js
@@ -81,12 +81,11 @@ export const mapRequest = (request) => {
  */
 export const mapResponse = (response) => {
   const { data } = response;
-  if (data.length - 1) {
-    return JSON.stringify(
-      data?.query.map(({ code, description }) => ({ code, name: description })) ?? []
-    );
+  const { query: payload = [] } = data;
+  if (payload.length - 1) {
+    return JSON.stringify(payload.map(({ code, description }) => ({ code, name: description })));
   } else {
-    const [{ code, description }] = data?.query ?? [];
+    const [{ code, description }] = payload ?? [{}];
     return JSON.stringify({ code, name: description });
   }
 };

--- a/api/src/mappers.js
+++ b/api/src/mappers.js
@@ -1,3 +1,5 @@
+import { items as itemQueries } from './queries';
+
 const PARAMETERS = {
   '/items': ['code', 'exact', 'fields', 'fuzzy', 'inclusive', 'name', 'search'],
 };
@@ -32,31 +34,9 @@ export const parseRequest = (request) => {
 export const mapRequest = (request) => {
   const { query } = request;
   const { code, search } = query;
-
-  if (code) {
-    return `{
-      query(func: has(code)) @filter(eq(code, ${code}))
-      {	
-        code
-        description
-      }
-    }`;
-  } else if (search) {
-    return `{
-      query(func: has(code)) @filter(allofterms(description, "${search}")) {
-        code
-        description
-      }
-    }`;
-  } else {
-    // Default to all unit of use entities
-    return `{
-      query(func: has(code)) @filter(eq(type,"unit_of_use")) {
-        code
-        description
-      }
-    }`;
-  }
+  if (code) return { query: itemQueries.get, vars: { code } };
+  else if (search) return { query: itemQueries.search, vars: { search } };
+  else return { query: itemQueries.all, vars: {} };
 };
 
 /**

--- a/api/src/mappers.js
+++ b/api/src/mappers.js
@@ -34,8 +34,8 @@ export const parseRequest = (request) => {
 export const mapRequest = (request) => {
   const { query } = request;
   const { code, search } = query;
-  if (code) return { query: itemQueries.get, vars: { code } };
-  else if (search) return { query: itemQueries.search, vars: { search } };
+  if (code) return { query: itemQueries.get, vars: { $code: code } };
+  else if (search) return { query: itemQueries.search, vars: { $search: search } };
   else return { query: itemQueries.all, vars: {} };
 };
 

--- a/api/src/queries.js
+++ b/api/src/queries.js
@@ -6,7 +6,13 @@ const items = {
     }
   }`,
   search: `{
-    query(func: has(code)) @filter(allofterms(description, "$search")) {
+    query(func: has(code)) @filter(eq(description, $name) AND eq(type, "unit_of_use")) {
+      code
+      description
+    }
+  }`,
+  searchExact: `{
+    query(func: has(code)) @filter(regexp(description, "^$name.*$", "i") AND eq(type, "unit_of_use")) {
       code
       description
     }
@@ -22,3 +28,4 @@ const items = {
 export { items };
 
 export default { items };
+

--- a/api/src/queries.js
+++ b/api/src/queries.js
@@ -1,23 +1,22 @@
 const items = {
   get: `{
-        query(func: has(code)) @filter(eq(code, $code)) {	
-          code
-          description
-        }
-      }
-    }`,
+    query(func: has(code)) @filter(eq(code, $code)) {	
+      code
+      description
+    }
+  }`,
   search: `{
-        query(func: has(code)) @filter(allofterms(description, "$search")) {
-          code
-          description
-        }
-    }`,
+    query(func: has(code)) @filter(allofterms(description, "$search")) {
+      code
+      description
+    }
+  }`,
   all: `{
-        query(func: has(code)) @filter(eq(type,"unit_of_use")) {
-            code
-            description
-        }
-    }`,
+    query(func: has(code)) @filter(eq(type,"unit_of_use")) {
+      code
+      description
+    }
+  }`,
 };
 
 export { items };

--- a/api/src/queries.js
+++ b/api/src/queries.js
@@ -1,0 +1,25 @@
+const items = {
+  get: `{
+        query(func: has(code)) @filter(eq(code, $code)) {	
+          code
+          description
+        }
+      }
+    }`,
+  search: `{
+        query(func: has(code)) @filter(allofterms(description, "$search")) {
+          code
+          description
+        }
+    }`,
+  all: `{
+        query(func: has(code)) @filter(eq(type,"unit_of_use")) {
+            code
+            description
+        }
+    }`,
+};
+
+export { items };
+
+export default { items };

--- a/api/src/schemas.js
+++ b/api/src/schemas.js
@@ -1,35 +1,29 @@
-import S from "fluent-schema";
+import S from 'fluent-schema';
 
 const healthSchema = {
   response: {
-    200: S.object().prop("mysql", S.string()).prop("api", S.string()),
+    200: S.object().prop('mysql', S.string()).prop('api', S.string()),
   },
 };
 
 const itemsSchema = {
-  queryString: S.object().prop("code", S.string()),
+  queryString: S.object().prop('code', S.string()),
   response: {
     200: S.object(),
-    404: S.object().prop("error", S.string()),
+    404: S.object().prop('error', S.string()),
   },
 };
 
 const versionSchema = {
   response: {
-    200: S.object()
-      .prop("version", S.string())
-      .prop("versionShort", S.string()),
+    200: S.object().prop('version', S.string()).prop('versionShort', S.string()),
   },
 };
 
-export {
-  healthSchema as health,
-  itemsSchema as items,
-  versionSchema as version
-};
+export { healthSchema as health, itemsSchema as items, versionSchema as version };
 
 export default {
   health: healthSchema,
   items: itemsSchema,
-  version: versionSchema
+  version: versionSchema,
 };

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -5,125 +5,140 @@ import { apiResponses, graphResponses, data } from './fixtures';
 import api from '../src/api';
 import queries from '../src/queries';
 
-describe("Test health endpoint", () => {
-    test("Health endpoint response has status code 200", done => {
-        api.inject({
-            method: 'GET',
-            url: '/health'
-        }).then(response => {
-            const { statusCode } = response;
-            expect(statusCode).toBe(200);
-            done();
-        });
-    });
+describe('Test health endpoint', () => {
+  test('Health endpoint response has status code 200', (done) => {
+    api
+      .inject({
+        method: 'GET',
+        url: '/health',
+      })
+      .then((response) => {
+        const { statusCode } = response;
+        expect(statusCode).toBe(200);
+        done();
+      });
+  });
 });
 
-describe("Test items endpoint", () => {
-    test("Items endpoint with no params has status code 200", done => {
-        nock("http://localhost:8080")
-          .post('/query')
-          .query(queryObject => !!queryObject.timeout)
-          .reply(200, graphResponses.items.all);
-        api.inject({
-            method: 'GET',
-            url: '/items'
-        }).then(response => {
-            const { statusCode } = response;
-            expect(statusCode).toBe(200);
-            done();
-        });
-    });
+describe('Test items endpoint', () => {
+  test('Items endpoint with no params has status code 200', (done) => {
+    nock('http://localhost:8080')
+      .post('/query')
+      .query((queryObject) => !!queryObject.timeout)
+      .reply(200, graphResponses.items.all);
+    api
+      .inject({
+        method: 'GET',
+        url: '/items',
+      })
+      .then((response) => {
+        const { statusCode } = response;
+        expect(statusCode).toBe(200);
+        done();
+      });
+  });
 
-    test("Items endpoint with no params returns all items", done => {
-        nock('http://localhost:8080')
-            .post('/query')
-            .query(queryObject => !!queryObject.timeout)
-            .reply(200, graphResponses.items.all);
-        api.inject({
-            method: 'GET',
-            url: '/items',
-        }).then(response => {
-            const { body } = response;
-            expect(body).toBe(JSON.stringify(apiResponses.items.all));
-            done();
-        });
-    });
+  test('Items endpoint with no params returns all items', (done) => {
+    nock('http://localhost:8080')
+      .post('/query')
+      .query((queryObject) => !!queryObject.timeout)
+      .reply(200, graphResponses.items.all);
+    api
+      .inject({
+        method: 'GET',
+        url: '/items',
+      })
+      .then((response) => {
+        const { body } = response;
+        expect(body).toBe(JSON.stringify(apiResponses.items.all));
+        done();
+      });
+  });
 
-    test("Items endpoint with valid code returns matching item", done => {
-        const { items } = data;
-        const [item] = items;
-        const { code } = item;
+  test('Items endpoint with valid code returns matching item', (done) => {
+    const { items } = data;
+    const [item] = items;
+    const { code } = item;
 
-        nock("http://localhost:8080")
-            .post('/query')
-            .query(queryObject => !!queryObject.timeout)
-            .reply(200, (_, requestBody) => {
-              const { query, variables } = requestBody;
-              const validQuery = query === queries.items.get;
-              const validVariables = variables.code === code;
-              if (validQuery && validVariables) {
-                return graphResponses.items[code];
-              }
-            });
+    nock('http://localhost:8080')
+      .post('/query')
+      .query((queryObject) => !!queryObject.timeout)
+      .reply(200, (_, requestBody) => {
+        const { query, variables } = requestBody;
+        const validQuery = query === queries.items.get;
+        const validVariables = variables.code === code;
+        if (validQuery && validVariables) {
+          return graphResponses.items[code];
+        }
+      });
 
-        api.inject({
-            method: 'GET',
-            url: `/items?code=${code}`
-        }).then(response => {
-            const { body } = response;
-            expect(body).toBe(JSON.stringify(apiResponses.items[code]));
-            done();
-        });
-    });
+    api
+      .inject({
+        method: 'GET',
+        url: `/items?code=${code}`,
+      })
+      .then((response) => {
+        const { body } = response;
+        expect(body).toBe(JSON.stringify(apiResponses.items[code]));
+        done();
+      });
+  });
 
-    test("Items endpoint with invalid params has status code 400", done => {
-        api.inject({
-            method: 'GET',
-            url: '/items',
-            query: ({ badQuery: 'invalidData' })
-        }).then(response => {
-            const { statusCode } = response;
-            expect(statusCode).toBe(400);
-            done();
-        });
-    });
-
+  test('Items endpoint with invalid params has status code 400', (done) => {
+    api
+      .inject({
+        method: 'GET',
+        url: '/items',
+        query: { invalidParam: 'invalidData' },
+      })
+      .then((response) => {
+        const { statusCode } = response;
+        expect(statusCode).toBe(400);
+        done();
+      });
+  });
 });
 
-describe("Test version endpoint", () => {
-    test("Version endpoint response has status code 200", done => {
-        api.inject({
-            method: 'GET',
-            url: '/version'
-        }).then(response => {
-            const { statusCode } = response;
-            expect(statusCode).toBe(200);
-            done();
-        });
-    });
+describe('Test version endpoint', () => {
+  test('Version endpoint response has status code 200', (done) => {
+    api
+      .inject({
+        method: 'GET',
+        url: '/version',
+      })
+      .then((response) => {
+        const { statusCode } = response;
+        expect(statusCode).toBe(200);
+        done();
+      });
+  });
 
-    test("Version endpoint response has body with version properties", done => {
-        api.inject({
-            method: 'GET',
-            url: '/version'
-        }).then(response => {
-            const body = response.json();
-            expect(body).toHaveProperty('version');
-            expect(body).toHaveProperty('versionShort');
-            done();
-        });
-    });
+  test('Version endpoint response has body with version properties', (done) => {
+    api
+      .inject({
+        method: 'GET',
+        url: '/version',
+      })
+      .then((response) => {
+        const body = response.json();
+        expect(body).toHaveProperty('version');
+        expect(body).toHaveProperty('versionShort');
+        done();
+      });
+  });
 });
 
-describe("Test invalid endpoint", () => {
-    test("Invalid endpoint response has status code 404", done => {
-        api.inject({
-            method: 'GET',
-            url: '/invalid'
-        }).then(response => {
-            const { statusCode } = response;
-            expect(statusCode).toBe(404);
-            done();
-        });
-    });
+describe('Test invalid endpoint', () => {
+  test('Invalid endpoint response has status code 404', (done) => {
+    api
+      .inject({
+        method: 'GET',
+        url: '/invalid',
+      })
+      .then((response) => {
+        const { statusCode } = response;
+        expect(statusCode).toBe(404);
+        done();
+      });
+  });
 });

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -84,6 +84,79 @@ describe('Test items endpoint', () => {
       });
   });
 
+  test('Items endpoint with exact name search returns matching item', (done) => {
+    const { items } = data;
+    const [item] = items;
+    const { code, name } = item;
+
+    nock('http://localhost:8080')
+      .post('/query')
+      .query((queryObject) => !!queryObject.timeout)
+      .reply(200, (_, requestBody) => {
+        const { query, variables } = requestBody;
+        const validQuery = query === queries.items.searchExact;
+        const validVariables = variables.$name === name;
+        if (validQuery && validVariables) {
+          return graphResponses.items[code];
+        }
+      });
+
+    api
+      .inject({
+        method: 'GET',
+        url: `/items?name=${name}&exact=true`,
+      })
+      .then((response) => {
+        const { body } = response;
+        expect(body).toBe(JSON.stringify(apiResponses.items[code]));
+        done();
+      });
+  });
+
+  test('Items endpoint with non-exact name search returns matching items', (done) => {
+    const { items } = data;
+    const [item] = items;
+    const { code, name } = item;
+
+    const searchName = name.substring(0, 3);
+    const searchCodes = items.filter(item => item.name.startsWith(searchName)).map(item => item.code);
+
+    const apiResponse = Object.entries(apiResponses.items).reduce((acc, [key, value]) => {
+      if (searchCodes.includes(key)) {
+        return acc.concat(value);
+      }
+      return acc;
+    }, []);
+
+    const graphResponse = Object.entries(graphResponses.items).reduce((acc, [key, value]) => {
+      if (key != code && searchCodes.includes(key)) acc.data.query.concat(value.data.query);
+      return acc;
+    }, graphResponses.items[code]);
+
+    nock('http://localhost:8080')
+      .post('/query')
+      .query((queryObject) => !!queryObject.timeout)
+      .reply(200, (_, requestBody) => {
+        const { query, variables } = requestBody;
+        const validQuery = query === queries.items.search;
+        const validVariables = variables.$name === searchName;
+        if (validQuery && validVariables) {
+          return graphResponse;
+        }
+      });
+
+    api
+      .inject({
+        method: 'GET',
+        url: `/items?name=${searchName}&exact=false`,
+      })
+      .then((response) => {
+        const { body } = response;
+        expect(body).toBe(JSON.stringify(apiResponse));
+        done();
+      });
+  });
+
   test('Items endpoint with invalid params has status code 400', (done) => {
     api
       .inject({

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -1,5 +1,6 @@
-import api from "../src/api";
+import { apiResponses, graphResponses, data } from './fixtures';
 
+import api from '../src/api';
 import queries from '../src/queries';
 
 describe("Test health endpoint", () => {

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -19,7 +19,11 @@ describe("Test health endpoint", () => {
 });
 
 describe("Test items endpoint", () => {
-    test("Items endpoint response has status code 200", done => {
+    test("Items endpoint with no params has status code 200", done => {
+        nock("http://localhost:8080")
+          .post('/query')
+          .query(queryObject => !!queryObject.timeout)
+          .reply(200, graphResponses.items.all);
         api.inject({
             method: 'GET',
             url: '/items'

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -66,7 +66,7 @@ describe('Test items endpoint', () => {
       .reply(200, (_, requestBody) => {
         const { query, variables } = requestBody;
         const validQuery = query === queries.items.get;
-        const validVariables = variables.code === code;
+        const validVariables = variables.$code === code;
         if (validQuery && validVariables) {
           return graphResponses.items[code];
         }

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -1,5 +1,7 @@
 import api from "../src/api";
 
+import queries from '../src/queries';
+
 describe("Test health endpoint", () => {
     test("Health endpoint response has status code 200", done => {
         api.inject({

--- a/api/test/api.test.js
+++ b/api/test/api.test.js
@@ -1,3 +1,5 @@
+import nock from 'nock';
+
 import { apiResponses, graphResponses, data } from './fixtures';
 
 import api from '../src/api';

--- a/api/test/fixtures/api/index.js
+++ b/api/test/fixtures/api/index.js
@@ -1,0 +1,5 @@
+import items from './items.json';
+
+export const apiResponses = { items };
+
+export default apiResponses;

--- a/api/test/fixtures/api/items.json
+++ b/api/test/fixtures/api/items.json
@@ -13,16 +13,16 @@
       "name": "Amoxicillin oral capsule, 250mg"
     }
   ],
-  "5589F4BF": {
+  "5589F4BF": [{
     "code": "5589F4BF",
     "name": "Paracetamol oral tablet, 300mg"
-  },
-  "368C74BE": {
+  }],
+  "368C74BE": [{
     "code": "368C74BE",
     "name": "Amoxicillin oral tablet 500mg"
-  },
-  "368C74BF": {
+  }],
+  "368C74BF": [{
     "code": "368C74BF",
     "name": "Amoxicillin oral capsule, 250mg"
-  }
+  }]
 }

--- a/api/test/fixtures/api/items.json
+++ b/api/test/fixtures/api/items.json
@@ -1,0 +1,28 @@
+{
+  "all": [
+    {
+      "code": "5589F4BF",
+      "name": "Paracetamol oral tablet, 300mg"
+    },
+    {
+      "code": "368C74BE",
+      "name": "Amoxicillin oral tablet 500mg"
+    },
+    {
+      "code": "368C74BF",
+      "name": "Amoxicillin oral capsule, 250mg"
+    }
+  ],
+  "5589F4BF": {
+    "code": "5589F4BF",
+    "name": "Paracetamol oral tablet, 300mg"
+  },
+  "368C74BE": {
+    "code": "368C74BE",
+    "name": "Amoxicillin oral tablet 500mg"
+  },
+  "368C74BF": {
+    "code": "368C74BF",
+    "name": "Amoxicillin oral capsule, 250mg"
+  }
+}

--- a/api/test/fixtures/data/index.js
+++ b/api/test/fixtures/data/index.js
@@ -1,0 +1,5 @@
+import items from './items.json';
+
+export const data = { items };
+
+export default data;

--- a/api/test/fixtures/data/items.json
+++ b/api/test/fixtures/data/items.json
@@ -1,0 +1,14 @@
+[
+  {
+    "code": "5589F4BF",
+    "name": "Paracetamol oral tablet, 300mg"
+  },
+  {
+    "code": "368C74BE",
+    "name": "Amoxicillin oral tablet 500mg"
+  },
+  {
+    "code": "368C74BF",
+    "name": "Amoxicillin oral capsule, 250mg"
+  }
+]

--- a/api/test/fixtures/graph/index.js
+++ b/api/test/fixtures/graph/index.js
@@ -1,0 +1,5 @@
+import items from './items.json';
+
+export const graphResponses = { items };
+
+export default graphResponses;

--- a/api/test/fixtures/graph/items.json
+++ b/api/test/fixtures/graph/items.json
@@ -1,0 +1,70 @@
+{
+  "all": {
+    "data": {
+      "query": [
+        {
+          "code": "5589F4BF",
+          "description": "Paracetamol oral tablet, 300mg"
+        },
+        {
+          "code": "368C74BE",
+          "description": "Amoxicillin oral tablet 500mg"
+        },
+        {
+          "code": "368C74BF",
+          "description": "Amoxicillin oral capsule, 250mg"
+        }
+      ]
+    },
+    "extensions": {
+      "txn": {
+        "start_ts": 1
+      }
+    }
+  },
+  "5589F4BF": {
+    "data": {
+      "query": [
+        {
+          "code": "5589F4BF",
+          "description": "Paracetamol oral tablet, 300mg"
+        }
+      ]
+    },
+    "extensions": {
+      "txn": {
+        "start_ts": 1
+      }
+    }
+  },
+  "368C74BE": {
+    "data": {
+      "query": [
+        {
+          "code": "368C74BE",
+          "name": "Amoxicillin oral tablet 500mg"
+        }
+      ]
+    },
+    "extensions": {
+      "txn": {
+        "start_ts": 1
+      }
+    }
+  },
+  "368C74BF": {
+    "data": {
+      "query": [
+        {
+          "code": "368C74BF",
+          "name": "Amoxicillin oral capsule, 250mg"
+        }
+      ]
+    },
+    "extensions": {
+      "txn": {
+        "start_ts": 1
+      }
+    }
+  }
+}

--- a/api/test/fixtures/index.js
+++ b/api/test/fixtures/index.js
@@ -1,0 +1,4 @@
+export { data } from './data';
+
+export { apiResponses } from './api';
+export { graphResponses } from './graph';


### PR DESCRIPTION
Fixes #27,

Completes the testing template for the v1 API, including:

- Fixtures:
  - Test data.
  - Expected graph responses.
  - Expected API responses.
- Additional `/items` tests, including examples of:
    - Using fixtures for test data, expected responses etc.
    - Simulating Dgraph responses with basic and bit more advanced `nock` functionality.


  