### PR TITLE
#41 add drug interaction lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,1 @@
-# npm
-node_modules
-
-# babel
-dgraph/graphql/lib
-
 .DS_Store

--- a/dgraph/.gitignore
+++ b/dgraph/.gitignore
@@ -1,0 +1,5 @@
+# npm
+node_modules
+
+# babel
+graphql/lib

--- a/dgraph/graphql/src/api.js
+++ b/dgraph/graphql/src/api.js
@@ -9,8 +9,8 @@ const server = new ApolloServer({
   resolvers,
   dataSources: () => {
     return {
-      dgraphDataSource: new DgraphDataSource(),
-      rxNavDataSource: new RxNavDataSource()
+      dgraph: new DgraphDataSource(),
+      rxNav: new RxNavDataSource()
     };
   },
 });

--- a/dgraph/graphql/src/api.js
+++ b/dgraph/graphql/src/api.js
@@ -1,7 +1,7 @@
 import { ApolloServer } from 'apollo-server-fastify';
 import fastify from 'fastify';
 import { typeDefs } from './schema';
-import { dgraph } from './data';
+import { DgraphDataSource } from './data';
 
 const resolvers = {
   Query: {
@@ -23,7 +23,7 @@ const server = new ApolloServer({
   resolvers,
   dataSources: () => {
     return {
-      dgraphDataSource: new dgraph(),
+      dgraphDataSource: new DgraphDataSource(),
     };
   },
 });

--- a/dgraph/graphql/src/api.js
+++ b/dgraph/graphql/src/api.js
@@ -1,22 +1,8 @@
 import { ApolloServer } from 'apollo-server-fastify';
 import fastify from 'fastify';
 import { typeDefs } from './schema';
-import { DgraphDataSource } from './data';
-
-const resolvers = {
-  Query: {
-    searchByName: async (_source, _args, { dataSources }) => {
-      const dgraphQuery = `{
-        query(func: regexp(description, /^${_args.text}/i)) @filter(has(code) AND eq(type, "unit_of_use")) {
-          code
-          description
-        }
-      }`;
-      const resp = await dataSources.dgraphDataSource.postQuery(dgraphQuery);
-      return resp.data.query;
-    },
-  },
-};
+import { DgraphDataSource, RxNavDataSource } from './data';
+import { resolvers } from './resolvers'
 
 const server = new ApolloServer({
   typeDefs,
@@ -24,6 +10,7 @@ const server = new ApolloServer({
   dataSources: () => {
     return {
       dgraphDataSource: new DgraphDataSource(),
+      rxNavDataSource: new RxNavDataSource()
     };
   },
 });

--- a/dgraph/graphql/src/data.js
+++ b/dgraph/graphql/src/data.js
@@ -1,18 +1,18 @@
 import { RESTDataSource } from 'apollo-datasource-rest';
 
-export class dgraph extends RESTDataSource {
+export class DgraphDataSource extends RESTDataSource {
   constructor() {
     super();
     this.baseURL = 'http://localhost:8080';
-  }
-
+    this.headers = { 'Content-Type': 'application/graphql+-' };
+    this.paths = { query: 'query' };
+  };
+  
   willSendRequest(request) {
-    request.headers.set('Content-Type', 'application/graphql+-');
+    Object.entries(this.headers).forEach(([key, value]) => request.headers.set(key, value));
   }
-
-  async postQuery(dgraphQuery) {
-    const path = 'query';
-
-    return this.post(path, dgraphQuery);
+  
+  async postQuery(query) {
+    return this.post(this.paths.query, query);
   }
 }

--- a/dgraph/graphql/src/data.js
+++ b/dgraph/graphql/src/data.js
@@ -16,3 +16,17 @@ export class DgraphDataSource extends RESTDataSource {
     return this.post(this.paths.query, query);
   }
 }
+
+export class RxNavDataSource extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = 'https://rxnav.nlm.nih.gov/REST';
+    this.paths = { interactions: 'interaction/interaction.json' }
+  }
+  
+  async getInteractions(rxCui) {
+    const resp = this.get(this.paths.interactions, { rxcui: rxCui });
+    
+    return resp;
+  }
+}

--- a/dgraph/graphql/src/data.js
+++ b/dgraph/graphql/src/data.js
@@ -25,8 +25,6 @@ export class RxNavDataSource extends RESTDataSource {
   }
   
   async getInteractions(rxCui) {
-    const resp = this.get(this.paths.interactions, { rxcui: rxCui });
-    
-    return resp;
+    return this.get(this.paths.interactions, { rxcui: rxCui });
   }
 }

--- a/dgraph/graphql/src/resolvers.js
+++ b/dgraph/graphql/src/resolvers.js
@@ -1,4 +1,5 @@
 import { UserInputError } from 'apollo-server-fastify';
+import GraphQLJSON from 'graphql-type-json';
 
 const resolvers = {
   Query: {
@@ -27,13 +28,13 @@ const resolvers = {
 
       // If RxCui found - Query RxNav for Interactions 
       if (response.data.query.length) {
-        const rxCui = response.data.query[0].has_property.value;
-        const rxNavResponse = await dataSources.rxNavDataSource.getInteractions(rxCui);
-        return [{ name: 'fakeDrug', description: 'fakeInteraction', severity: 'high' }];
+        const rxCui = response.data.query[0].has_property[0].value;
+        return await dataSources.rxNavDataSource.getInteractions(rxCui);
       }
       throw new UserInputError(`No RxCUI found for product with code ${_args.code}`);
     }
   },
+  JSON: GraphQLJSON
 };
 
 export { resolvers };

--- a/dgraph/graphql/src/resolvers.js
+++ b/dgraph/graphql/src/resolvers.js
@@ -10,7 +10,7 @@ const resolvers = {
           description
         }
       }`;
-      const response = await dataSources.dgraphDataSource.postQuery(dgraphQuery);
+      const response = await dataSources.dgraph.postQuery(dgraphQuery);
       return response.data.query;
     },
     getDrugInteractions: async (_source, _args, { dataSources }) => {
@@ -23,12 +23,12 @@ const resolvers = {
             }
         }
       }`;
-      const response = await dataSources.dgraphDataSource.postQuery(dgraphQuery);
+      const response = await dataSources.dgraph.postQuery(dgraphQuery);
 
       // If RxCui found - Query RxNav for Interactions 
       if (response.data.query.length) {
         const rxCui = response.data.query[0].has_property[0].value;
-        return await dataSources.rxNavDataSource.getInteractions(rxCui);
+        return await dataSources.rxNav.getInteractions(rxCui);
       }
       throw new UserInputError(`No RxCUI found for product with code ${_args.code}`);
     }

--- a/dgraph/graphql/src/resolvers.js
+++ b/dgraph/graphql/src/resolvers.js
@@ -1,0 +1,20 @@
+const resolvers = {
+  Query: {
+    searchByName: async (_source, _args, { dataSources }) => {
+      const dgraphQuery = `{
+        query(func: has(code)) @filter(regexp(description, /^${_args.text}.*$/i) AND eq(type, "unit_of_use")) {
+          code
+          description
+        }
+      }`;
+      const resp = await dataSources.dgraphDataSource.postQuery(dgraphQuery);
+      return resp.data.query;
+    },
+    getDrugInteractions: async (_source, _args, { dataSources }) => {
+      const resp = await dataSources.rxNavDataSource.getInteractions(_args.rxCui);
+      return [{ name: 'fakeDrug', description: 'fakeInteraction', severity: 'high' }];
+    }
+  },
+};
+
+export { resolvers };

--- a/dgraph/graphql/src/resolvers.js
+++ b/dgraph/graphql/src/resolvers.js
@@ -2,7 +2,7 @@ const resolvers = {
   Query: {
     searchByName: async (_source, _args, { dataSources }) => {
       const dgraphQuery = `{
-        query(func: has(code)) @filter(regexp(description, /^${_args.text}.*$/i) AND eq(type, "unit_of_use")) {
+        query(func: regexp(description, /^${_args.text}/i)) @filter(has(code) AND eq(type, "unit_of_use")) {
           code
           description
         }

--- a/dgraph/graphql/src/resolvers.js
+++ b/dgraph/graphql/src/resolvers.js
@@ -18,7 +18,6 @@ const resolvers = {
       const dgraphQuery = `{
         query(func: eq(code, ${_args.code}))
         {
-            description
             has_property @filter(eq(type, "RxNorm RxCUI")) {
               value
             }

--- a/dgraph/graphql/src/schema.js
+++ b/dgraph/graphql/src/schema.js
@@ -17,7 +17,7 @@ const typeDefs = gql`
 
   type Query {
     searchByName(text: String): [Entity]
-    getDrugInteractions(rxCui: String): [DrugInteraction]
+    getDrugInteractions(code: String): [DrugInteraction]
   }
 
   type DrugInteraction {

--- a/dgraph/graphql/src/schema.js
+++ b/dgraph/graphql/src/schema.js
@@ -16,8 +16,8 @@ const typeDefs = gql`
   }
 
   type Query {
-    searchByName(text: String): [Entity]
-    getDrugInteractions(code: String): [DrugInteraction]
+    searchByName(text: String!): [Entity]
+    getDrugInteractions(code: String!): [DrugInteraction]
   }
 
   type DrugInteraction {

--- a/dgraph/graphql/src/schema.js
+++ b/dgraph/graphql/src/schema.js
@@ -17,6 +17,13 @@ const typeDefs = gql`
 
   type Query {
     searchByName(text: String): [Entity]
+    getDrugInteractions(rxCui: String): [DrugInteraction]
+  }
+
+  type DrugInteraction {
+    name: String
+    description: String
+    severity: String
   }
 `;
 

--- a/dgraph/graphql/src/schema.js
+++ b/dgraph/graphql/src/schema.js
@@ -1,6 +1,8 @@
 import { gql } from 'apollo-server-fastify';
 
 const typeDefs = gql`
+  scalar JSON
+  
   type Entity {
     type: String!
     code: String
@@ -17,13 +19,7 @@ const typeDefs = gql`
 
   type Query {
     searchByName(text: String!): [Entity]
-    getDrugInteractions(code: String!): [DrugInteraction]
-  }
-
-  type DrugInteraction {
-    name: String
-    description: String
-    severity: String
+    getDrugInteractions(code: String!): JSON
   }
 `;
 

--- a/dgraph/package-lock.json
+++ b/dgraph/package-lock.json
@@ -2671,6 +2671,11 @@
         }
       }
     },
+    "graphql-type-json": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
+      "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
+    },
     "graphql-upload": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",

--- a/dgraph/package.json
+++ b/dgraph/package.json
@@ -7,7 +7,8 @@
     "apollo-datasource-rest": "^0.9.3",
     "apollo-server-fastify": "^2.15.1",
     "fastify": "^3.0.2",
-    "graphql": "^15.3.0"
+    "graphql": "^15.3.0",
+    "graphql-type-json": "^0.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #41 

## Description
<!--- Briefly describe your changes -->
- Applied following feedback from prior PR  
  - Git Ignore: https://github.com/openmsupply/unified-codes/pull/55#discussion_r454751477
  - Class Naming: https://github.com/openmsupply/unified-codes/pull/55#discussion_r454764168
  - Class Constructor: https://github.com/openmsupply/unified-codes/pull/55#discussion_r454768144
-  New query added to schema (getDrugInteractions with universal code as input parameter)
- Custom resolver added to first query Dgraph for the RXCui, then query RxNav

**Future Improvements**
- Had some discussion with Craig and this sort of aligns with the previous demo on interactions, although it is now a GraphQL request/response rather than REST. Future improvement may be to structure this better (return properties rather than huge JSON string) and implement a backward compatible version that returns the huge JSON string in the REST API.
- Possibly we may want to expand the functionality to search parent/child nodes for a RXCui in the DB, currently we'll only return results if the currently queried node has RXCui as a direct property.

Sample Custom Query
`{
  getDrugInteractions (code: "368C74BF")
}`

Sample Response
`{
"data": { 
"getDrugInteractions": { [RxNav JSON Payload]
}
}
}`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
