### PR TITLE
#168 add pagination to explorer

### DIFF
--- a/unified-codes/apps/data-service/src/app/queries.ts
+++ b/unified-codes/apps/data-service/src/app/queries.ts
@@ -11,7 +11,7 @@ export const queries = {
         }
       }`;
   },
-  entities: (type: string, pageSize: number, after: number) => {
+  entities: (type: string, first: number, offset: number) => {
     return `{
       query(func: eq(type, ${type})) @filter(has(description)) @recurse(loop: false)  {
         code

--- a/unified-codes/apps/data-service/src/app/queries.ts
+++ b/unified-codes/apps/data-service/src/app/queries.ts
@@ -1,7 +1,7 @@
 export const queries = {
   entity: (code: string) => {
     return `{
-        query(func: eq(code, ${code})) @recurse(loop: false)  {
+        query(func: eq(code, ${code}), first: 1) @recurse(loop: false)  {
           code
           description
           type
@@ -11,7 +11,7 @@ export const queries = {
         }
       }`;
   },
-  entities: (type: string, first: number, offset: number) => {
+  entities: (type: string) => {
     return `{
       query(func: eq(type, ${type})) @filter(has(description)) @recurse(loop: false)  {
         code

--- a/unified-codes/apps/data-service/src/app/queries.ts
+++ b/unified-codes/apps/data-service/src/app/queries.ts
@@ -1,5 +1,5 @@
 export const queries = {
-  entity: (code) => {
+  entity: (code: string) => {
     return `{
         query(func: eq(code, ${code})) @recurse(loop: false)  {
           code
@@ -11,7 +11,7 @@ export const queries = {
         }
       }`;
   },
-  entities: (type) => {
+  entities: (type: string, pageSize: number, after: number) => {
     return `{
       query(func: eq(type, ${type})) @filter(has(description)) @recurse(loop: false)  {
         code

--- a/unified-codes/apps/data-service/src/app/resolvers.ts
+++ b/unified-codes/apps/data-service/src/app/resolvers.ts
@@ -74,6 +74,7 @@ export const resolvers = {
         pageSize,
         results: allEntities,
       };
+
       return getPaginatedResults<IEntity>(paginationParameters);
     },
   },

--- a/unified-codes/apps/data-service/src/app/resolvers.ts
+++ b/unified-codes/apps/data-service/src/app/resolvers.ts
@@ -2,33 +2,7 @@ import { IApolloServiceContext, User } from '@unified-codes/data';
 import { DgraphDataSource } from './data';
 import { getPaginatedResults } from './utils';
 import { IEntity, IPaginationParameters } from '@unified-codes/data';
-
-const queries = {
-  entity: (code: string) => {
-    return `{
-        query(func: eq(code, ${code}), first: 1) @recurse(loop: false)  {
-          code
-          description
-          type
-          value
-          has_child
-          has_property
-        }
-      }`;
-  },
-  entities: (type: string) => {
-    return `{
-      query(func: eq(type, ${type})) @filter(has(description)) @recurse(loop: false)  {
-        code
-        description
-        type
-        value
-        has_child
-        has_property
-      }
-    }`;
-  },
-};
+import { queries } from './queries';
 
 export const resolvers = {
   Query: {
@@ -65,7 +39,7 @@ export const resolvers = {
         console.log(`Entity requested by anonymous user.`);
       }
 
-      const { type = 'medicinal_product' } = args?.filter ?? {};
+      const { type = 'medicinal_product' } = filter ?? {};
       const query = queries.entities(type);
       const response = await dgraph.postQuery(query);
       const allEntities: Array<IEntity> = response.data.query;

--- a/unified-codes/apps/data-service/src/app/resolvers.ts
+++ b/unified-codes/apps/data-service/src/app/resolvers.ts
@@ -54,7 +54,7 @@ export const resolvers = {
     entities: async (_source: any, args: any, context: IApolloServiceContext) => {
       const { token, authenticator, authoriser, dataSources } = context;
       const dgraph: DgraphDataSource = dataSources.dgraph as DgraphDataSource;
-      const { after, filter, pageSize = 20 } = args;
+      const { filter, first, offset } = args;
 
       // TODO: add authorisation logic for any protected entities.
       if (token) {
@@ -70,11 +70,10 @@ export const resolvers = {
       const response = await dgraph.postQuery(query);
       const allEntities: Array<IEntity> = response.data.query;
       const paginationParameters: IPaginationParameters<IEntity> = {
-        after,
-        pageSize,
+        first,
+        offset,
         results: allEntities,
       };
-
       return getPaginatedResults<IEntity>(paginationParameters);
     },
   },

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -19,7 +19,13 @@ const typeDefs = gql`
     "Request an entity by code"
     entity(code: String!): Entity
     "Request all entities with optional filter - Default behaviour: return all medicinal_products"
-    entities(filter: SearchFilter): [Entity]
+    entities(filter: SearchFilter, pageSize: Int, after: String): EntityConnection
+  }
+
+  type EntityConnection {
+    cursor: String!
+    hasMore: Boolean!
+    entities: [Entity]!
   }
 
   input SearchFilter {

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -19,11 +19,11 @@ const typeDefs = gql`
     "Request an entity by code"
     entity(code: String!): Entity
     "Request all entities with optional filter - Default behaviour: return all medicinal_products"
-    entitiesQuery(filter: SearchFilter, first: Int, offset: Int): EntitiesQueryResult
+    entities(filter: SearchFilter, first: Int, offset: Int): EntitiesResponse
   }
 
-  type EntitiesQueryResult {
-    entities: [Entity]!
+  type EntitiesResponse {
+    data: [Entity]!
     hasMore: Boolean!
     totalResults: Int!
   }

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -19,11 +19,10 @@ const typeDefs = gql`
     "Request an entity by code"
     entity(code: String!): Entity
     "Request all entities with optional filter - Default behaviour: return all medicinal_products"
-    entities(filter: SearchFilter, pageSize: Int, after: String): EntityConnection
+    entities(filter: SearchFilter, first: Int, offset: Int): EntityConnection
   }
 
   type EntityConnection {
-    cursor: String
     entities: [Entity]!
     hasMore: Boolean!
     totalResults: Int!

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -23,9 +23,10 @@ const typeDefs = gql`
   }
 
   type EntityConnection {
-    cursor: String!
-    hasMore: Boolean!
+    cursor: String
     entities: [Entity]!
+    hasMore: Boolean!
+    totalResults: Int!
   }
 
   input SearchFilter {

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -19,10 +19,10 @@ const typeDefs = gql`
     "Request an entity by code"
     entity(code: String!): Entity
     "Request all entities with optional filter - Default behaviour: return all medicinal_products"
-    entities(filter: SearchFilter, first: Int, offset: Int): EntityConnection
+    entitiesQuery(filter: SearchFilter, first: Int, offset: Int): EntitiesQueryResult
   }
 
-  type EntityConnection {
+  type EntitiesQueryResult {
     entities: [Entity]!
     hasMore: Boolean!
     totalResults: Int!

--- a/unified-codes/apps/data-service/src/app/utils.ts
+++ b/unified-codes/apps/data-service/src/app/utils.ts
@@ -21,5 +21,5 @@ function paginateResults<T>(params: IPaginationParameters<T>): Array<T> {
   // don't let us overflow
   if (offset === results.length - 1) return [];
 
-  return results.slice(offset + 1, Math.min(results.length, offset + 1 + first));
+  return results.slice(offset, Math.min(results.length, offset + first));
 }

--- a/unified-codes/apps/data-service/src/app/utils.ts
+++ b/unified-codes/apps/data-service/src/app/utils.ts
@@ -3,11 +3,11 @@ import { IPaginatedResults, IPaginationParameters } from '@unified-codes/data';
 export function getPaginatedResults<T>(params: IPaginationParameters<T>): IPaginatedResults<T> {
   const { results } = params;
   const totalResults = results.length;
-  const entities = paginateResults(params);
-  const entityCount = entities.length;
+  const data = paginateResults(params);
+  const entityCount = data.length;
 
   return {
-    entities,
+    data,
     hasMore: totalResults > entityCount,
     totalResults,
   };

--- a/unified-codes/apps/data-service/src/app/utils.ts
+++ b/unified-codes/apps/data-service/src/app/utils.ts
@@ -1,0 +1,48 @@
+import { IPaginatable, IPaginatedResults, IPaginationParameters } from '@unified-codes/data';
+
+export function getPaginatedResults<T extends IPaginatable>(
+  params: IPaginationParameters<T>
+): IPaginatedResults<T> {
+  const { results } = params;
+  const totalResults = results.length;
+  const entities = paginateResults(params);
+  const entityCount = entities.length;
+
+  return {
+    entities,
+    cursor: entityCount ? results[entityCount - 1].cursor : null,
+    // if the cursor at the end of the paginated results is the same as the
+    // last item in _all_ results, then there are no more results after this
+    hasMore: entityCount
+      ? entities[entityCount - 1].cursor !== results[totalResults - 1].cursor
+      : false,
+    totalResults,
+  };
+}
+
+function paginateResults<T extends IPaginatable>(params: IPaginationParameters<T>): Array<T> {
+  const {
+    after: cursor,
+    pageSize = 20,
+    results,
+    // can pass in a function to calculate an item's cursor
+    getCursor = () => null,
+  } = params;
+
+  if (pageSize < 1) return [];
+
+  if (!cursor) return results.slice(0, pageSize);
+  const cursorIndex = results.findIndex((item: T) => {
+    // if an item has a `cursor` on it, use that, otherwise try to generate one
+    let itemCursor = item.cursor ? item.cursor : getCursor(item);
+
+    // if there's still not a cursor, return false by default
+    return itemCursor ? cursor === itemCursor : false;
+  });
+
+  return cursorIndex >= 0
+    ? cursorIndex === results.length - 1 // don't let us overflow
+      ? []
+      : results.slice(cursorIndex + 1, Math.min(results.length, cursorIndex + 1 + pageSize))
+    : results.slice(0, pageSize);
+}

--- a/unified-codes/apps/data-service/src/app/utils.ts
+++ b/unified-codes/apps/data-service/src/app/utils.ts
@@ -1,8 +1,6 @@
-import { IPaginatable, IPaginatedResults, IPaginationParameters } from '@unified-codes/data';
+import { IPaginatedResults, IPaginationParameters } from '@unified-codes/data';
 
-export function getPaginatedResults<T extends IPaginatable>(
-  params: IPaginationParameters<T>
-): IPaginatedResults<T> {
+export function getPaginatedResults<T>(params: IPaginationParameters<T>): IPaginatedResults<T> {
   const { results } = params;
   const totalResults = results.length;
   const entities = paginateResults(params);
@@ -10,39 +8,18 @@ export function getPaginatedResults<T extends IPaginatable>(
 
   return {
     entities,
-    cursor: entityCount ? results[entityCount - 1].cursor : null,
-    // if the cursor at the end of the paginated results is the same as the
-    // last item in _all_ results, then there are no more results after this
-    hasMore: entityCount
-      ? entities[entityCount - 1].cursor !== results[totalResults - 1].cursor
-      : false,
+    hasMore: totalResults > entityCount,
     totalResults,
   };
 }
 
-function paginateResults<T extends IPaginatable>(params: IPaginationParameters<T>): Array<T> {
-  const {
-    after: cursor,
-    pageSize = 20,
-    results,
-    // can pass in a function to calculate an item's cursor
-    getCursor = () => null,
-  } = params;
+function paginateResults<T>(params: IPaginationParameters<T>): Array<T> {
+  const { first, offset, results } = params;
 
-  if (pageSize < 1) return [];
+  if (first < 1) return [];
+  if (!offset) return results.slice(0, first);
+  // don't let us overflow
+  if (offset === results.length - 1) return [];
 
-  if (!cursor) return results.slice(0, pageSize);
-  const cursorIndex = results.findIndex((item: T) => {
-    // if an item has a `cursor` on it, use that, otherwise try to generate one
-    let itemCursor = item.cursor ? item.cursor : getCursor(item);
-
-    // if there's still not a cursor, return false by default
-    return itemCursor ? cursor === itemCursor : false;
-  });
-
-  return cursorIndex >= 0
-    ? cursorIndex === results.length - 1 // don't let us overflow
-      ? []
-      : results.slice(cursorIndex + 1, Math.min(results.length, cursorIndex + 1 + pageSize))
-    : results.slice(0, pageSize);
+  return results.slice(offset + 1, Math.min(results.length, offset + 1 + first));
 }

--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { IEntity } from '@unified-codes/data';
+import { Entity, IPaginatedResults } from '@unified-codes/data';
 
 export const EXPLORER_ACTIONS = {
   FETCH_DATA: 'explorerActions/fetchData',
@@ -13,7 +13,7 @@ export const EXPLORER_ACTIONS = {
 export interface IExplorerFetchDataAction extends Action<string> {}
 
 export interface IExplorerFetchSuccessAction extends Action<string> {
-  data: IEntity[];
+  data: IPaginatedResults<Entity>;
 }
 
 export interface IExplorerFetchFailureAction extends Action<string> {
@@ -36,7 +36,7 @@ export const fetchData = () => ({
   type: EXPLORER_ACTIONS.FETCH_DATA,
 });
 
-export const fetchSuccess = (data: IEntity[]) => ({
+export const fetchSuccess = (data: IPaginatedResults<Entity>) => ({
   type: EXPLORER_ACTIONS.FETCH_SUCCESS,
   data,
 });

--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { Entity, IPaginatedResults } from '@unified-codes/data';
+import { Entity, IPaginationRequest, IPaginatedResults } from '@unified-codes/data';
 
 export const EXPLORER_ACTIONS = {
   FETCH_DATA: 'explorerActions/fetchData',
@@ -10,7 +10,9 @@ export const EXPLORER_ACTIONS = {
   RESET_VARIABLES: 'explorerActions/resetVariables',
 };
 
-export interface IExplorerFetchDataAction extends Action<string> {}
+export interface IExplorerFetchDataAction extends Action<string> {
+  request: IPaginationRequest;
+}
 
 export interface IExplorerFetchSuccessAction extends Action<string> {
   data: IPaginatedResults<Entity>;
@@ -32,8 +34,9 @@ export type IExplorerAction =
   | IExplorerFetchFailureAction
   | IExplorerUpdateVariablesAction;
 
-export const fetchData = () => ({
+export const fetchData = (request: IPaginationRequest) => ({
   type: EXPLORER_ACTIONS.FETCH_DATA,
+  request,
 });
 
 export const fetchSuccess = (data: IPaginatedResults<Entity>) => ({

--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -15,7 +15,7 @@ export interface IExplorerFetchDataAction extends Action<string> {
 }
 
 export interface IExplorerFetchSuccessAction extends Action<string> {
-  data: IPaginatedResults<Entity>;
+  entities: IPaginatedResults<Entity>;
 }
 
 export interface IExplorerFetchFailureAction extends Action<string> {
@@ -39,9 +39,9 @@ export const fetchData = (request: IPaginationRequest) => ({
   request,
 });
 
-export const fetchSuccess = (data: IPaginatedResults<Entity>) => ({
+export const fetchSuccess = (entities: IPaginatedResults<Entity>) => ({
   type: EXPLORER_ACTIONS.FETCH_SUCCESS,
-  data,
+  entities,
 });
 
 export const fetchFailure = (error: Error) => ({

--- a/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { Entity } from '@unified-codes/data';
+import { IExplorerData } from '../../types';
 
 import { ExplorerComponent } from './Explorer';
 
@@ -8,17 +9,15 @@ export default { title: 'Explorer' };
 
 export const withNoProps = () => {
   const [entities] = React.useState<Entity[]>([]);
+  const data: IExplorerData = {
+    entities,
+    hasMore: false,
+    totalResults: 0,
+  };
 
   const onReady = () => console.log('onReady called...');
   const onClear = () => console.log('onClear called...');
   const onSearch = () => console.log('onSearch called...');
 
-  return (
-    <ExplorerComponent
-      entities={entities}
-      onReady={onReady}
-      onClear={onClear}
-      onSearch={onSearch}
-    />
-  );
+  return <ExplorerComponent data={data} onReady={onReady} onClear={onClear} onSearch={onSearch} />;
 };

--- a/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
@@ -18,6 +18,15 @@ export const withNoProps = () => {
   const onReady = () => console.log('onReady called...');
   const onClear = () => console.log('onClear called...');
   const onSearch = () => console.log('onSearch called...');
+  const onFetch = () => console.log('onFetch called...');
 
-  return <ExplorerComponent data={data} onReady={onReady} onClear={onClear} onSearch={onSearch} />;
+  return (
+    <ExplorerComponent
+      data={data}
+      onReady={onReady}
+      onClear={onClear}
+      onSearch={onSearch}
+      onFetch={onFetch}
+    />
+  );
 };

--- a/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
@@ -10,7 +10,7 @@ export default { title: 'Explorer' };
 export const withNoProps = () => {
   const [entities] = React.useState<Entity[]>([]);
   const data: IExplorerData = {
-    entities,
+    data: entities,
     hasMore: false,
     totalResults: 0,
   };
@@ -22,7 +22,7 @@ export const withNoProps = () => {
 
   return (
     <ExplorerComponent
-      data={data}
+      entities={data}
       onReady={onReady}
       onClear={onClear}
       onSearch={onSearch}

--- a/unified-codes/apps/web/src/components/templates/Explorer.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.tsx
@@ -6,11 +6,11 @@ import { EntityBrowser, Grid } from '@unified-codes/ui';
 import { Entity } from '@unified-codes/data';
 
 import { ExplorerActions } from '../../actions';
-import { IState } from '../../types';
+import { IExplorerData, IState } from '../../types';
 import { ExplorerSelectors } from '../../selectors';
 
 export interface ExplorerProps {
-  entities: Entity[];
+  data?: IExplorerData;
   onReady: () => void;
   onClear: () => void;
   onSearch: (input: string) => void;
@@ -18,14 +18,20 @@ export interface ExplorerProps {
 
 export type Explorer = React.FunctionComponent<ExplorerProps>;
 
-export const ExplorerComponent: Explorer = ({ entities, onReady, onClear, onSearch }) => {
+export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onSearch }) => {
   React.useEffect(() => {
     onReady();
   }, []);
 
+  const entityData = data || {
+    entities: [] as Array<Entity>,
+    hasMore: false,
+    totalResults: 0,
+  };
+
   return (
     <Grid container justify="center">
-      <EntityBrowser entities={entities} onClear={onClear} onSearch={onSearch} />
+      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} />
     </Grid>
   );
 };

--- a/unified-codes/apps/web/src/components/templates/Explorer.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.tsx
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 
 import { EntityBrowser, Grid } from '@unified-codes/ui';
-import { Entity, IPaginationRequest } from '@unified-codes/data';
+import { Entity, IPaginationRequest, PaginationRequest } from '@unified-codes/data';
 
 import { ExplorerActions } from '../../actions';
 import { IExplorerData, IState } from '../../types';
@@ -43,7 +43,7 @@ const mapStateToProps = (state: IState) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   const onClear = () => dispatch(ExplorerActions.resetVariables());
-  const onReady = () => dispatch(ExplorerActions.fetchData({}));
+  const onReady = () => dispatch(ExplorerActions.fetchData(new PaginationRequest()));
   // TODO refactor when lifting search out
   const onFetch = (request: IPaginationRequest) => dispatch(ExplorerActions.fetchData(request));
   const onSearch = (input: string) =>

--- a/unified-codes/apps/web/src/components/templates/Explorer.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.tsx
@@ -10,7 +10,7 @@ import { IExplorerData, IState } from '../../types';
 import { ExplorerSelectors } from '../../selectors';
 
 export interface ExplorerProps {
-  data?: IExplorerData;
+  entities?: IExplorerData;
   onReady: () => void;
   onClear: () => void;
   onFetch: (request: IPaginationRequest) => void;
@@ -19,26 +19,31 @@ export interface ExplorerProps {
 
 export type Explorer = React.FunctionComponent<ExplorerProps>;
 
-export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onFetch, onSearch }) => {
+export const ExplorerComponent: Explorer = ({ entities, onReady, onClear, onFetch, onSearch }) => {
   React.useEffect(() => {
     onReady();
   }, []);
-  const entityData = data || {
-    entities: [] as Array<Entity>,
+  const entityData = entities || {
+    data: [] as Array<Entity>,
     hasMore: false,
     totalResults: 0,
   };
 
   return (
     <Grid container justify="center">
-      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} onFetch={onFetch} />
+      <EntityBrowser
+        entities={entityData}
+        onClear={onClear}
+        onSearch={onSearch}
+        onFetch={onFetch}
+      />
     </Grid>
   );
 };
 
 const mapStateToProps = (state: IState) => {
-  const data = ExplorerSelectors.entitiesSelector(state);
-  return { data };
+  const entities = ExplorerSelectors.entitiesSelector(state);
+  return { entities };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => {

--- a/unified-codes/apps/web/src/components/templates/Explorer.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.tsx
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 
 import { EntityBrowser, Grid } from '@unified-codes/ui';
-import { Entity } from '@unified-codes/data';
+import { Entity, IPaginationRequest } from '@unified-codes/data';
 
 import { ExplorerActions } from '../../actions';
 import { IExplorerData, IState } from '../../types';
@@ -13,16 +13,16 @@ export interface ExplorerProps {
   data?: IExplorerData;
   onReady: () => void;
   onClear: () => void;
+  onFetch: (request: IPaginationRequest) => void;
   onSearch: (input: string) => void;
 }
 
 export type Explorer = React.FunctionComponent<ExplorerProps>;
 
-export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onSearch }) => {
+export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onFetch, onSearch }) => {
   React.useEffect(() => {
     onReady();
   }, []);
-
   const entityData = data || {
     entities: [] as Array<Entity>,
     hasMore: false,
@@ -31,22 +31,24 @@ export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onSearch }
 
   return (
     <Grid container justify="center">
-      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} />
+      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} onFetch={onFetch} />
     </Grid>
   );
 };
 
 const mapStateToProps = (state: IState) => {
-  const entities = ExplorerSelectors.entitiesSelector(state);
-  return { entities };
+  const data = ExplorerSelectors.entitiesSelector(state);
+  return { data };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   const onClear = () => dispatch(ExplorerActions.resetVariables());
-  const onReady = () => dispatch(ExplorerActions.fetchData());
+  const onReady = () => dispatch(ExplorerActions.fetchData({}));
+  // TODO refactor when lifting search out
+  const onFetch = (request: IPaginationRequest) => dispatch(ExplorerActions.fetchData(request));
   const onSearch = (input: string) =>
     dispatch(ExplorerActions.updateVariables({ code: input, description: input }));
-  return { onClear, onReady, onSearch };
+  return { onClear, onFetch, onReady, onSearch };
 };
 
 export const Explorer = connect(mapStateToProps, mapDispatchToProps)(ExplorerComponent);

--- a/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
+++ b/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
@@ -10,8 +10,8 @@ import { Entity } from '@unified-codes/data';
 
 const initialState = (): IExplorerState => {
   return {
-    data: {
-      entities: [] as Array<Entity>,
+    entities: {
+      data: [] as Array<Entity>,
       hasMore: false,
       totalResults: 0,
     },
@@ -32,8 +32,8 @@ export const ExplorerReducer = (
     }
 
     case EXPLORER_ACTIONS.FETCH_SUCCESS: {
-      const { data } = action as IExplorerFetchSuccessAction;
-      return { ...state, data, loading: false };
+      const { entities } = action as IExplorerFetchSuccessAction;
+      return { ...state, entities, loading: false };
     }
 
     case EXPLORER_ACTIONS.FETCH_FAILURE: {
@@ -42,7 +42,7 @@ export const ExplorerReducer = (
     }
 
     case EXPLORER_ACTIONS.RESET_DATA: {
-      return { ...state, data: initialState().data };
+      return { ...state, entities: initialState().entities };
     }
 
     case EXPLORER_ACTIONS.UPDATE_VARIABLES: {

--- a/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
+++ b/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
@@ -6,15 +6,24 @@ import {
   IExplorerFetchSuccessAction,
 } from '../actions';
 import { IExplorerState } from '../types';
+import { Entity } from '@unified-codes/data';
 
 const initialState = (): IExplorerState => {
   return {
+    data: {
+      entities: [] as Array<Entity>,
+      hasMore: false,
+      totalResults: 0,
+    },
     loading: false,
     variables: {},
   };
 };
 
-export const ExplorerReducer = (state = initialState(), action: IExplorerAction) => {
+export const ExplorerReducer = (
+  state = initialState(),
+  action: IExplorerAction
+): IExplorerState => {
   const { type } = action;
 
   switch (type) {
@@ -33,7 +42,7 @@ export const ExplorerReducer = (state = initialState(), action: IExplorerAction)
     }
 
     case EXPLORER_ACTIONS.RESET_DATA: {
-      return { ...state, data: [] };
+      return { ...state, data: initialState().data };
     }
 
     case EXPLORER_ACTIONS.UPDATE_VARIABLES: {

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -19,7 +19,7 @@ import {
 const getEntitiesQuery = (first: number, offset?: number) => `
   {
     entities(offset: ${offset} first: ${first}) {
-      entities {
+      data {
         code
         description
         type
@@ -79,10 +79,9 @@ function* fetchData(action: IExplorerFetchDataAction) {
       | string
       | undefined = `${process.env.NX_DATA_SERVICE_URL}:${process.env.NX_DATA_SERVICE_PORT}/${process.env.NX_DATA_SERVICE_GRAPHQL}`;
     if (url) {
-      const data: IPaginatedResults<Entity> = yield call(getEntities, url, action.request);
-
+      const entities: IPaginatedResults<Entity> = yield call(getEntities, url, action.request);
       yield put(AlertActions.resetAlert());
-      yield put(ExplorerActions.fetchSuccess(data));
+      yield put(ExplorerActions.fetchSuccess(entities));
     }
   } catch (error) {
     yield put(AlertActions.raiseAlert(alertError));

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -63,7 +63,7 @@ const getEntities = async (
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
-    body: JSON.stringify({ query: getEntitiesQuery(request.first || 25, request.offset || 0) }),
+    body: JSON.stringify({ query: getEntitiesQuery(request.first, request.offset) }),
   });
   const json = await response.json();
   const { data } = json;

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -1,17 +1,32 @@
 import { call, put, takeEvery, all } from 'redux-saga/effects';
 
-import { AlertSeverity, Entity, IAlert, IPaginatedResults } from '@unified-codes/data';
+import {
+  AlertSeverity,
+  Entity,
+  IAlert,
+  IPaginatedResults,
+  IPaginationRequest,
+} from '@unified-codes/data';
 
-import { EXPLORER_ACTIONS, ExplorerActions, AlertActions, IExplorerAction } from '../actions';
+import {
+  EXPLORER_ACTIONS,
+  ExplorerActions,
+  AlertActions,
+  IExplorerAction,
+  IExplorerFetchDataAction,
+} from '../actions';
 
-const GET_ENTITIES = `
+const getEntitiesQuery = (page: number, rowsPerPage: number) => `
   {
-    entities(pageSize: 3) {
+    entities( pageSize: ${rowsPerPage}) {
       entities {
         code
         description
         type
-      }
+      },
+      cursor,
+      hasMore,
+      totalResults,
     }
   }
 `;
@@ -39,30 +54,33 @@ const alertFetch: IAlert = {
 };
 
 // TODO: add helper class for raw gql queries to data library and refactor this!
-const getEntities = async (url: string): Promise<IPaginatedResults<Entity>> => {
+const getEntities = async (
+  url: string,
+  request: IPaginationRequest
+): Promise<IPaginatedResults<Entity>> => {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
-    body: JSON.stringify({ query: GET_ENTITIES }),
+    body: JSON.stringify({ query: getEntitiesQuery(request.page || 0, request.rowsPerPage || 25) }),
   });
   const json = await response.json();
   const { data } = json;
+  const { entities } = data;
 
-  return data;
+  return entities;
 };
 
-function* fetchData() {
+function* fetchData(action: IExplorerFetchDataAction) {
   yield put(AlertActions.raiseAlert(alertFetch));
-
   try {
     const url:
       | string
       | undefined = `${process.env.NX_DATA_SERVICE_URL}:${process.env.NX_DATA_SERVICE_PORT}/${process.env.NX_DATA_SERVICE_GRAPHQL}`;
     if (url) {
-      const data: IPaginatedResults<Entity> = yield call(getEntities, url);
+      const data: IPaginatedResults<Entity> = yield call(getEntities, url, action.request);
       yield put(AlertActions.resetAlert());
       yield put(ExplorerActions.fetchSuccess(data));
     }

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -16,15 +16,14 @@ import {
   IExplorerFetchDataAction,
 } from '../actions';
 
-const getEntitiesQuery = (page: number, rowsPerPage: number) => `
+const getEntitiesQuery = (first: number, offset?: number) => `
   {
-    entities( pageSize: ${rowsPerPage}) {
+    entities(offset: ${offset} first: ${first}) {
       entities {
         code
         description
         type
       },
-      cursor,
       hasMore,
       totalResults,
     }
@@ -64,7 +63,7 @@ const getEntities = async (
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
-    body: JSON.stringify({ query: getEntitiesQuery(request.page || 0, request.rowsPerPage || 25) }),
+    body: JSON.stringify({ query: getEntitiesQuery(request.first || 25, request.offset || 0) }),
   });
   const json = await response.json();
   const { data } = json;
@@ -81,6 +80,7 @@ function* fetchData(action: IExplorerFetchDataAction) {
       | undefined = `${process.env.NX_DATA_SERVICE_URL}:${process.env.NX_DATA_SERVICE_PORT}/${process.env.NX_DATA_SERVICE_GRAPHQL}`;
     if (url) {
       const data: IPaginatedResults<Entity> = yield call(getEntities, url, action.request);
+
       yield put(AlertActions.resetAlert());
       yield put(ExplorerActions.fetchSuccess(data));
     }

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -29,7 +29,7 @@ export const entitiesSelector = createSelector(
     );
     return {
       ...entities,
-      entities: filteredEntities,
+      data: filteredEntities,
     };
   }
 );

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -21,14 +21,15 @@ export const entitiesSelector = createSelector(
   dataSelector,
   (variables?: IExplorerVariables, data?: IExplorerData) => {
     const { code = '', description = '' } = variables ?? {};
-    const allEntities: Entity[] = data?.entities.map((entity: IEntity) => new Entity(entity)) ?? [];
+    const allEntities: Entity[] =
+      data?.entities?.map((entity: IEntity) => new Entity(entity)) ?? [];
     // TODO: push this filter down
     const filteredEntities: Entity[] = allEntities.filter(
       (entity: Entity) => entity.matchesCode(code) || entity.matchesDescription(description)
     );
     return {
-      entities: filteredEntities,
       ...data,
+      entities: filteredEntities,
     };
   }
 );

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -13,22 +13,22 @@ export const variablesSelector = createSelector(
 
 export const dataSelector = createSelector(
   explorerSelector,
-  (explorer: IExplorerState): IExplorerData | undefined => explorer.data
+  (explorer: IExplorerState): IExplorerData | undefined => explorer.entities
 );
 
 export const entitiesSelector = createSelector(
   variablesSelector,
   dataSelector,
-  (variables?: IExplorerVariables, data?: IExplorerData) => {
+  (variables?: IExplorerVariables, entities?: IExplorerData) => {
     const { code = '', description = '' } = variables ?? {};
     const allEntities: Entity[] =
-      data?.entities?.map((entity: IEntity) => new Entity(entity)) ?? [];
+      entities?.data?.map((entity: IEntity) => new Entity(entity)) ?? [];
     // TODO: push this filter down
     const filteredEntities: Entity[] = allEntities.filter(
       (entity: Entity) => entity.matchesCode(code) || entity.matchesDescription(description)
     );
     return {
-      ...data,
+      ...entities,
       entities: filteredEntities,
     };
   }

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -21,11 +21,15 @@ export const entitiesSelector = createSelector(
   dataSelector,
   (variables?: IExplorerVariables, data?: IExplorerData) => {
     const { code = '', description = '' } = variables ?? {};
-    const allEntities: Entity[] = data?.map((entity: IEntity) => new Entity(entity)) ?? [];
+    const allEntities: Entity[] = data?.entities.map((entity: IEntity) => new Entity(entity)) ?? [];
+    // TODO: push this filter down
     const filteredEntities: Entity[] = allEntities.filter(
       (entity: Entity) => entity.matchesCode(code) || entity.matchesDescription(description)
     );
-    return filteredEntities;
+    return {
+      entities: filteredEntities,
+      ...data,
+    };
   }
 );
 

--- a/unified-codes/apps/web/src/types/Store.ts
+++ b/unified-codes/apps/web/src/types/Store.ts
@@ -10,7 +10,7 @@ export type IExplorerData = {
   cursor?: string;
   hasMore: boolean;
   totalResults: number;
-  entities: Entity[];
+  data: Entity[];
 };
 
 export interface IExplorerVariables {
@@ -19,7 +19,7 @@ export interface IExplorerVariables {
 }
 
 export interface IExplorerState {
-  data?: IExplorerData;
+  entities?: IExplorerData;
   error?: Error;
   loading?: boolean;
   variables?: IExplorerVariables;

--- a/unified-codes/apps/web/src/types/Store.ts
+++ b/unified-codes/apps/web/src/types/Store.ts
@@ -1,4 +1,4 @@
-import { IAlert, IEntity, IUser } from '@unified-codes/data';
+import { Entity, IAlert, IUser } from '@unified-codes/data';
 
 export type IAlertState = IAlert | {};
 
@@ -6,7 +6,12 @@ export interface IAuthenticatorState {
   isAuthenticating?: boolean;
 }
 
-export type IExplorerData = IEntity[];
+export type IExplorerData = {
+  cursor?: string;
+  hasMore: boolean;
+  totalResults: number;
+  entities: Entity[];
+};
 
 export interface IExplorerVariables {
   code?: string;

--- a/unified-codes/libs/data/src/lib/types/Entity.ts
+++ b/unified-codes/libs/data/src/lib/types/Entity.ts
@@ -1,7 +1,6 @@
-import { IPaginatable } from './Pagination';
 import { Property } from './Property';
 
-export interface IEntity extends IPaginatable {
+export interface IEntity {
   code: string;
   description: string;
   type: string;
@@ -10,14 +9,12 @@ export interface IEntity extends IPaginatable {
 
 export class Entity implements IEntity {
   private _code: string;
-  private _cursor?: string;
   private _description: string;
   private _type: string;
   private _properties?: Property[];
 
   constructor(entity: IEntity) {
     this._code = entity.code;
-    this._cursor = entity.cursor;
     this._description = entity.description;
     this._type = entity.type;
     this._properties = entity.properties;
@@ -25,10 +22,6 @@ export class Entity implements IEntity {
 
   get code(): string {
     return this._code;
-  }
-
-  get cursor(): string {
-    return this._cursor || '';
   }
 
   get description(): string {

--- a/unified-codes/libs/data/src/lib/types/Entity.ts
+++ b/unified-codes/libs/data/src/lib/types/Entity.ts
@@ -1,6 +1,7 @@
+import { IPaginatable } from './Pagination';
 import { Property } from './Property';
 
-export interface IEntity {
+export interface IEntity extends IPaginatable {
   code: string;
   description: string;
   type: string;
@@ -9,12 +10,14 @@ export interface IEntity {
 
 export class Entity implements IEntity {
   private _code: string;
+  private _cursor?: string;
   private _description: string;
   private _type: string;
   private _properties?: Property[];
 
   constructor(entity: IEntity) {
     this._code = entity.code;
+    this._cursor = entity.cursor;
     this._description = entity.description;
     this._type = entity.type;
     this._properties = entity.properties;
@@ -22,6 +25,10 @@ export class Entity implements IEntity {
 
   get code(): string {
     return this._code;
+  }
+
+  get cursor(): string {
+    return this._cursor || '';
   }
 
   get description(): string {

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -1,22 +1,16 @@
-export interface IPaginatable {
-  cursor?: string;
-}
-
-export interface IPaginationParameters<T extends IPaginatable> {
-  after: string;
-  pageSize: number;
+export interface IPaginationParameters<T> {
+  offset: number;
+  first: number;
   results: Array<T>;
-  getCursor?: (item: T) => null | Array<T>;
 }
 
-export interface IPaginatedResults<T extends IPaginatable> {
+export interface IPaginatedResults<T> {
   entities: Array<T>;
-  cursor?: string;
   hasMore: boolean;
   totalResults: number;
 }
 
 export interface IPaginationRequest {
-  page?: number;
-  rowsPerPage?: number;
+  first?: number;
+  offset?: number;
 }

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -1,0 +1,17 @@
+export interface IPaginatable {
+  cursor?: string;
+}
+
+export interface IPaginationParameters<T extends IPaginatable> {
+  after: string;
+  pageSize: number;
+  results: Array<T>;
+  getCursor?: (item: T) => null | Array<T>;
+}
+
+export interface IPaginatedResults<T extends IPaginatable> {
+  entities: Array<T>;
+  cursor?: string;
+  hasMore: boolean;
+  totalResults: number;
+}

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -5,7 +5,7 @@ export interface IPaginationParameters<T> {
 }
 
 export interface IPaginatedResults<T> {
-  entities: Array<T>;
+  data: Array<T>;
   hasMore: boolean;
   totalResults: number;
 }

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -15,3 +15,8 @@ export interface IPaginatedResults<T extends IPaginatable> {
   hasMore: boolean;
   totalResults: number;
 }
+
+export interface IPaginationRequest {
+  page?: number;
+  rowsPerPage?: number;
+}

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -11,6 +11,23 @@ export interface IPaginatedResults<T> {
 }
 
 export interface IPaginationRequest {
-  first?: number;
-  offset?: number;
+  first: number;
+  offset: number;
+}
+export class PaginationRequest implements IPaginationRequest {
+  _first: number;
+  _offset: number;
+
+  constructor(first?: number, offset?: number) {
+    this._first = first || 25;
+    this._offset = offset || 0;
+  }
+
+  get first(): number {
+    return this._first;
+  }
+
+  get offset(): number {
+    return this._offset;
+  }
 }

--- a/unified-codes/libs/data/src/lib/types/index.ts
+++ b/unified-codes/libs/data/src/lib/types/index.ts
@@ -5,5 +5,6 @@ export * from './AuthorisationService';
 export * from './Entity';
 export * from './IdentityProvider';
 export * from './JWT';
+export * from './Pagination';
 export * from './Property';
 export * from './User';

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.stories.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.stories.tsx
@@ -10,7 +10,7 @@ export default {
 };
 
 export const withNoProps = () => {
-  const data: IEntity[] = [
+  const entities: IEntity[] = [
     {
       code: 'QFWR9789',
       description: 'Amoxicillin',
@@ -22,6 +22,7 @@ export const withNoProps = () => {
       type: 'medicinal_product',
     },
   ];
-  const entities = data.map((entityNode: IEntity) => new Entity(entityNode));
-  return <EntityBrowser entities={entities} />;
+  const data = entities.map((entityNode: IEntity) => new Entity(entityNode));
+  const entityData = { data, hasMore: false, totalResults: 2 };
+  return <EntityBrowser entities={entityData} />;
 };

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -9,7 +9,7 @@ import TablePagination from '@material-ui/core/TablePagination';
 import { IPaginationRequest, PaginationRequest } from '@unified-codes/data';
 
 export interface EntityBrowserProps {
-  data: IPaginatedResults<Entity>;
+  entities: IPaginatedResults<Entity>;
   onChange?: (value: string) => void;
   onClear?: () => void;
   onFetch?: (request: IPaginationRequest) => void;
@@ -20,7 +20,13 @@ export type EntityBrowser = React.FunctionComponent<EntityBrowserProps>;
 type RowsPerPageEvent = React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>;
 type MouseEvent = React.MouseEvent<HTMLButtonElement> | null;
 
-export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch, onSearch }) => {
+export const EntityBrowser: EntityBrowser = ({
+  entities,
+  onChange,
+  onClear,
+  onFetch,
+  onSearch,
+}) => {
   const [input, setInput] = React.useState('');
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
@@ -53,13 +59,13 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch,
         <SearchBar input={input} onChange={onChangeInput} onClear={onClear} onSearch={onSearch} />
       </Grid>
       <Grid item style={{ maxHeight: 400, overflow: 'scroll' }}>
-        <EntityTable data={data.entities} />
+        <EntityTable data={entities.data} />
       </Grid>
       <Grid item>
         <TablePagination
           rowsPerPageOptions={[10, 25, 100]}
           component="div"
-          count={data.totalResults}
+          count={entities.totalResults}
           rowsPerPage={rowsPerPage}
           page={page}
           onChangePage={handleChangePage}

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -6,7 +6,7 @@ import EntityTable from '../molecules/EntityTable';
 import Grid from '../../layout/atoms/Grid';
 import SearchBar from '../../inputs/molecules/SearchBar';
 import TablePagination from '@material-ui/core/TablePagination';
-import { IPaginationRequest } from '@unified-codes/data';
+import { IPaginationRequest, PaginationRequest } from '@unified-codes/data';
 
 export interface EntityBrowserProps {
   data: IPaginatedResults<Entity>;
@@ -35,21 +35,15 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch,
 
   const handleChangePage = (_: MouseEvent, newPage: number) => {
     setPage(newPage);
-    handleFetch(newPage, rowsPerPage);
+    const request = new PaginationRequest(rowsPerPage, newPage * rowsPerPage);
+    onFetch && onFetch(request);
   };
 
   const handleChangeRowsPerPage = (event: RowsPerPageEvent) => {
     const rowsPerPage = +event.target.value;
     setRowsPerPage(rowsPerPage);
     setPage(0);
-    handleFetch(0, rowsPerPage);
-  };
-
-  const handleFetch = (page: number, rowsPerPage: number) => {
-    const request: IPaginationRequest = {
-      first: rowsPerPage,
-      offset: page * rowsPerPage,
-    };
+    const request = new PaginationRequest(rowsPerPage);
     onFetch && onFetch(request);
   };
 

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -6,11 +6,13 @@ import EntityTable from '../molecules/EntityTable';
 import Grid from '../../layout/atoms/Grid';
 import SearchBar from '../../inputs/molecules/SearchBar';
 import TablePagination from '@material-ui/core/TablePagination';
+import { IPaginationRequest } from '@unified-codes/data';
 
 export interface EntityBrowserProps {
   data: IPaginatedResults<Entity>;
   onChange?: (value: string) => void;
   onClear?: () => void;
+  onFetch?: (request: IPaginationRequest) => void;
   onSearch?: (value: string) => void;
 }
 
@@ -18,7 +20,7 @@ export type EntityBrowser = React.FunctionComponent<EntityBrowserProps>;
 type RowsPerPageEvent = React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>;
 type MouseEvent = React.MouseEvent<HTMLButtonElement> | null;
 
-export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onSearch }) => {
+export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch, onSearch }) => {
   const [input, setInput] = React.useState('');
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
@@ -33,11 +35,18 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onSearch
 
   const handleChangePage = (_: MouseEvent, newPage: number) => {
     setPage(newPage);
+    handleFetch(newPage, rowsPerPage);
   };
 
   const handleChangeRowsPerPage = (event: RowsPerPageEvent) => {
-    setRowsPerPage(+event.target.value);
+    const rowsPerPage = +event.target.value;
+    setRowsPerPage(rowsPerPage);
     setPage(0);
+    handleFetch(0, rowsPerPage);
+  };
+
+  const handleFetch = (page: number, rowsPerPage: number) => {
+    onFetch({ page, rowsPerPage });
   };
 
   return (
@@ -45,8 +54,10 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onSearch
       <Grid item>
         <SearchBar input={input} onChange={onChangeInput} onClear={onClear} onSearch={onSearch} />
       </Grid>
-      <Grid item>
+      <Grid item style={{ maxHeight: 400, overflow: 'scroll' }}>
         <EntityTable data={data.entities} />
+      </Grid>
+      <Grid item>
         <TablePagination
           rowsPerPageOptions={[10, 25, 100]}
           component="div"

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -46,7 +46,11 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch,
   };
 
   const handleFetch = (page: number, rowsPerPage: number) => {
-    onFetch({ page, rowsPerPage });
+    const request: IPaginationRequest = {
+      first: rowsPerPage,
+      offset: page * rowsPerPage,
+    };
+    onFetch && onFetch(request);
   };
 
   return (

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -1,22 +1,27 @@
 import * as React from 'react';
 
-import { Entity } from '@unified-codes/data';
+import { Entity, IPaginatedResults } from '@unified-codes/data';
 
 import EntityTable from '../molecules/EntityTable';
 import Grid from '../../layout/atoms/Grid';
 import SearchBar from '../../inputs/molecules/SearchBar';
+import TablePagination from '@material-ui/core/TablePagination';
 
 export interface EntityBrowserProps {
-  entities: Entity[];
+  data: IPaginatedResults<Entity>;
   onChange?: (value: string) => void;
   onClear?: () => void;
   onSearch?: (value: string) => void;
 }
 
 export type EntityBrowser = React.FunctionComponent<EntityBrowserProps>;
+type RowsPerPageEvent = React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>;
+type MouseEvent = React.MouseEvent<HTMLButtonElement> | null;
 
-export const EntityBrowser: EntityBrowser = ({ entities, onChange, onClear, onSearch }) => {
+export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onSearch }) => {
   const [input, setInput] = React.useState('');
+  const [page, setPage] = React.useState(0);
+  const [rowsPerPage, setRowsPerPage] = React.useState(25);
 
   const onChangeInput = React.useCallback(
     (input: string) => {
@@ -26,13 +31,31 @@ export const EntityBrowser: EntityBrowser = ({ entities, onChange, onClear, onSe
     [setInput]
   );
 
+  const handleChangePage = (_: MouseEvent, newPage: number) => {
+    setPage(newPage);
+  };
+
+  const handleChangeRowsPerPage = (event: RowsPerPageEvent) => {
+    setRowsPerPage(+event.target.value);
+    setPage(0);
+  };
+
   return (
     <Grid container direction="column">
       <Grid item>
         <SearchBar input={input} onChange={onChangeInput} onClear={onClear} onSearch={onSearch} />
       </Grid>
       <Grid item>
-        <EntityTable data={entities} />
+        <EntityTable data={data.entities} />
+        <TablePagination
+          rowsPerPageOptions={[10, 25, 100]}
+          component="div"
+          count={data.totalResults}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          onChangePage={handleChangePage}
+          onChangeRowsPerPage={handleChangeRowsPerPage}
+        />
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #168 

## Description
Adds pagination support to the entity browser table. Each request is making a round trip back to the data-service. Ok for now, may change that later.
Started off using cursors and have ditched - this is much less code.
Am using the nomenclature from https://dgraph.io/tour/basic/9/ i.e. `first` and `offset` rather than `page` and `rowsPerPage`

Next steps:
- add in filter / search support
- add ordering of results
- remove hard coded max height ( this just helps me test, as all items are on the page! ) and fix up styles ( #152  )

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [x] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
