### PR TITLE
#170 add filter to explorer request

### DIFF
--- a/unified-codes/apps/data-service/src/app/queries.ts
+++ b/unified-codes/apps/data-service/src/app/queries.ts
@@ -11,9 +11,21 @@ export const queries = {
         }
       }`;
   },
-  entities: (type: string) => {
+  entitiesByType: (type: string) => {
     return `{
       query(func: eq(type, ${type})) @filter(has(description)) @recurse(loop: false)  {
+        code
+        description
+        type
+        value
+        has_child
+        has_property
+      }
+    }`;
+  },
+  entitiesByDescriptionAndType: (type: string, description: string) => {
+    return `{
+      query(func: eq(type, ${type})) @filter(regexp(description, /.*${description}.*/i)) @recurse(loop: false)  {
         code
         description
         type

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -29,6 +29,10 @@ const typeDefs = gql`
   }
 
   input SearchFilter {
+    "Search by entity code"
+    code: String
+    "Search by entity description"
+    description: String
     "Search by Level in Product Hierarchy"
     type: String
   }

--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -1,5 +1,10 @@
 import { Action } from 'redux';
-import { Entity, IEntitySearchRequest, IPaginatedResults } from '@unified-codes/data';
+import {
+  Entity,
+  IEntitySearchRequest,
+  IExplorerVariables,
+  IPaginatedResults,
+} from '@unified-codes/data';
 
 export const EXPLORER_ACTIONS = {
   FETCH_DATA: 'explorerActions/fetchData',
@@ -25,7 +30,7 @@ export interface IExplorerFetchFailureAction extends Action<string> {
 export interface IExplorerResetDataAction extends Action<string> {}
 
 export interface IExplorerUpdateVariablesAction extends Action<string> {
-  variables: object;
+  variables: IExplorerVariables;
 }
 
 export type IExplorerAction =

--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -1,5 +1,5 @@
 import { Action } from 'redux';
-import { Entity, IPaginationRequest, IPaginatedResults } from '@unified-codes/data';
+import { Entity, IEntitySearchRequest, IPaginatedResults } from '@unified-codes/data';
 
 export const EXPLORER_ACTIONS = {
   FETCH_DATA: 'explorerActions/fetchData',
@@ -11,7 +11,7 @@ export const EXPLORER_ACTIONS = {
 };
 
 export interface IExplorerFetchDataAction extends Action<string> {
-  request: IPaginationRequest;
+  request: IEntitySearchRequest;
 }
 
 export interface IExplorerFetchSuccessAction extends Action<string> {
@@ -34,7 +34,7 @@ export type IExplorerAction =
   | IExplorerFetchFailureAction
   | IExplorerUpdateVariablesAction;
 
-export const fetchData = (request: IPaginationRequest) => ({
+export const fetchData = (request: IEntitySearchRequest) => ({
   type: EXPLORER_ACTIONS.FETCH_DATA,
   request,
 });

--- a/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
@@ -18,15 +18,6 @@ export const withNoProps = () => {
   const onReady = () => console.log('onReady called...');
   const onClear = () => console.log('onClear called...');
   const onSearch = () => console.log('onSearch called...');
-  const onFetch = () => console.log('onFetch called...');
 
-  return (
-    <ExplorerComponent
-      data={data}
-      onReady={onReady}
-      onClear={onClear}
-      onSearch={onSearch}
-      onFetch={onFetch}
-    />
-  );
+  return <ExplorerComponent data={data} onReady={onReady} onClear={onClear} onSearch={onSearch} />;
 };

--- a/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.stories.tsx
@@ -16,8 +16,15 @@ export const withNoProps = () => {
   };
 
   const onReady = () => console.log('onReady called...');
-  const onClear = () => console.log('onClear called...');
+  const onUpdateVariables = () => console.log('onUpdateVariables called...');
   const onSearch = () => console.log('onSearch called...');
 
-  return <ExplorerComponent data={data} onReady={onReady} onClear={onClear} onSearch={onSearch} />;
+  return (
+    <ExplorerComponent
+      data={data}
+      onReady={onReady}
+      onSearch={onSearch}
+      onUpdateVariables={onUpdateVariables}
+    />
+  );
 };

--- a/unified-codes/apps/web/src/components/templates/Explorer.tsx
+++ b/unified-codes/apps/web/src/components/templates/Explorer.tsx
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux';
 import { connect } from 'react-redux';
 
 import { EntityBrowser, Grid } from '@unified-codes/ui';
-import { Entity, IPaginationRequest, PaginationRequest } from '@unified-codes/data';
+import { Entity, EntitySearchRequest, IEntitySearchRequest } from '@unified-codes/data';
 
 import { ExplorerActions } from '../../actions';
 import { IExplorerData, IState } from '../../types';
@@ -13,13 +13,12 @@ export interface ExplorerProps {
   data?: IExplorerData;
   onReady: () => void;
   onClear: () => void;
-  onFetch: (request: IPaginationRequest) => void;
-  onSearch: (input: string) => void;
+  onSearch: (request: IEntitySearchRequest) => void;
 }
 
 export type Explorer = React.FunctionComponent<ExplorerProps>;
 
-export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onFetch, onSearch }) => {
+export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onSearch }) => {
   React.useEffect(() => {
     onReady();
   }, []);
@@ -31,7 +30,7 @@ export const ExplorerComponent: Explorer = ({ data, onReady, onClear, onFetch, o
 
   return (
     <Grid container justify="center">
-      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} onFetch={onFetch} />
+      <EntityBrowser data={entityData} onClear={onClear} onSearch={onSearch} />
     </Grid>
   );
 };
@@ -43,12 +42,9 @@ const mapStateToProps = (state: IState) => {
 
 const mapDispatchToProps = (dispatch: Dispatch) => {
   const onClear = () => dispatch(ExplorerActions.resetVariables());
-  const onReady = () => dispatch(ExplorerActions.fetchData(new PaginationRequest()));
-  // TODO refactor when lifting search out
-  const onFetch = (request: IPaginationRequest) => dispatch(ExplorerActions.fetchData(request));
-  const onSearch = (input: string) =>
-    dispatch(ExplorerActions.updateVariables({ code: input, description: input }));
-  return { onClear, onFetch, onReady, onSearch };
+  const onReady = () => dispatch(ExplorerActions.fetchData(new EntitySearchRequest()));
+  const onSearch = (request: IEntitySearchRequest) => dispatch(ExplorerActions.fetchData(request));
+  return { onClear, onReady, onSearch };
 };
 
 export const Explorer = connect(mapStateToProps, mapDispatchToProps)(ExplorerComponent);

--- a/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
+++ b/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
@@ -16,7 +16,11 @@ const initialState = (): IExplorerState => {
       totalResults: 0,
     },
     loading: false,
-    variables: {},
+    variables: {
+      page: 0,
+      rowsPerPage: 25,
+      type: 'medicinal_product',
+    },
   };
 };
 
@@ -51,7 +55,7 @@ export const ExplorerReducer = (
     }
 
     case EXPLORER_ACTIONS.RESET_VARIABLES: {
-      return { ...state, variables: {} };
+      return { ...state, variables: initialState().variables };
     }
 
     default:

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -3,6 +3,8 @@ import { call, put, takeEvery, all } from 'redux-saga/effects';
 import {
   AlertSeverity,
   Entity,
+  EntitySearchFilter,
+  EntitySearchRequest,
   IAlert,
   IPaginatedResults,
   IEntitySearchFilter,
@@ -15,6 +17,7 @@ import {
   AlertActions,
   IExplorerAction,
   IExplorerFetchDataAction,
+  IExplorerUpdateVariablesAction,
 } from '../actions';
 
 const getEntitiesQuery = (filter: IEntitySearchFilter, first: number, offset?: number) => `
@@ -97,8 +100,24 @@ function* fetchDataSaga() {
   yield takeEvery<IExplorerAction>(EXPLORER_ACTIONS.FETCH_DATA, fetchData);
 }
 
+function* updateVariables(action: IExplorerUpdateVariablesAction) {
+  const { variables } = action;
+  const { code, description, page, rowsPerPage, type } = variables;
+  const filter = new EntitySearchFilter(description, code, type);
+  const request = new EntitySearchRequest(filter, rowsPerPage, page);
+
+  yield put(ExplorerActions.fetchData(request));
+}
+
+function* updateVariablesSaga() {
+  yield takeEvery<IExplorerUpdateVariablesAction>(
+    EXPLORER_ACTIONS.UPDATE_VARIABLES,
+    updateVariables
+  );
+}
+
 export function* explorerSaga() {
-  yield all([fetchDataSaga()]);
+  yield all([fetchDataSaga(), updateVariablesSaga()]);
 }
 
 export default explorerSaga;

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -5,7 +5,8 @@ import {
   Entity,
   IAlert,
   IPaginatedResults,
-  IPaginationRequest,
+  IEntitySearchFilter,
+  IEntitySearchRequest,
 } from '@unified-codes/data';
 
 import {
@@ -16,9 +17,9 @@ import {
   IExplorerFetchDataAction,
 } from '../actions';
 
-const getEntitiesQuery = (first: number, offset?: number) => `
+const getEntitiesQuery = (filter: IEntitySearchFilter, first: number, offset?: number) => `
   {
-    entities(offset: ${offset} first: ${first}) {
+    entities(filter: { code: "${filter.code}" description: "${filter.description}" type: "${filter.type}" } offset: ${offset} first: ${first}) {
       entities {
         code
         description
@@ -55,7 +56,7 @@ const alertFetch: IAlert = {
 // TODO: add helper class for raw gql queries to data library and refactor this!
 const getEntities = async (
   url: string,
-  request: IPaginationRequest
+  request: IEntitySearchRequest
 ): Promise<IPaginatedResults<Entity>> => {
   const response = await fetch(url, {
     method: 'POST',
@@ -63,7 +64,9 @@ const getEntities = async (
       'Content-Type': 'application/json',
       Accept: 'application/json',
     },
-    body: JSON.stringify({ query: getEntitiesQuery(request.first, request.offset) }),
+    body: JSON.stringify({
+      query: getEntitiesQuery(request.filter, request.first, request.offset),
+    }),
   });
   const json = await response.json();
   const { data } = json;

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -1,8 +1,8 @@
 import { createSelector } from 'reselect';
 
-import { IEntity, Entity } from '@unified-codes/data';
+import { IEntity, IExplorerVariables, Entity } from '@unified-codes/data';
 
-import { IState, IExplorerState, IExplorerData, IExplorerVariables } from '../types';
+import { IState, IExplorerState, IExplorerData } from '../types';
 
 export const explorerSelector = (state: IState): IExplorerState => state.explorer;
 

--- a/unified-codes/apps/web/src/types/Store.ts
+++ b/unified-codes/apps/web/src/types/Store.ts
@@ -1,4 +1,4 @@
-import { Entity, IAlert, IUser } from '@unified-codes/data';
+import { Entity, IAlert, IExplorerVariables, IUser } from '@unified-codes/data';
 
 export type IAlertState = IAlert | {};
 
@@ -12,11 +12,6 @@ export type IExplorerData = {
   totalResults: number;
   entities: Entity[];
 };
-
-export interface IExplorerVariables {
-  code?: string;
-  description?: string;
-}
 
 export interface IExplorerState {
   data?: IExplorerData;

--- a/unified-codes/libs/data/src/lib/types/EntitySearch.ts
+++ b/unified-codes/libs/data/src/lib/types/EntitySearch.ts
@@ -1,0 +1,59 @@
+export interface IEntitySearchFilter {
+  code: string;
+  description: string;
+  type: string;
+}
+
+export interface IEntitySearchRequest {
+  filter: IEntitySearchFilter;
+  first: number;
+  offset: number;
+}
+
+export class EntitySearchFilter implements IEntitySearchFilter {
+  _code: string;
+  _description: string;
+  _type: string;
+
+  constructor(description?: string, code?: string, type?: string) {
+    this._code = code || '';
+    this._description = description || '';
+    this._type = type || 'medicinal_product';
+  }
+
+  get code(): string {
+    return this._code;
+  }
+
+  get description(): string {
+    return this._description;
+  }
+
+  get type(): string {
+    return this._type;
+  }
+}
+
+export class EntitySearchRequest implements IEntitySearchRequest {
+  _filter: IEntitySearchFilter;
+  _first: number;
+  _offset: number;
+
+  constructor(filter?: IEntitySearchFilter, first?: number, offset?: number) {
+    this._filter = filter || new EntitySearchFilter();
+    this._first = first || 25;
+    this._offset = offset || 0;
+  }
+
+  get filter(): IEntitySearchFilter {
+    return this._filter;
+  }
+
+  get first(): number {
+    return this._first;
+  }
+
+  get offset(): number {
+    return this._offset;
+  }
+}

--- a/unified-codes/libs/data/src/lib/types/Explorer.ts
+++ b/unified-codes/libs/data/src/lib/types/Explorer.ts
@@ -1,0 +1,7 @@
+export interface IExplorerVariables {
+  code?: string;
+  description?: string;
+  page?: number;
+  rowsPerPage?: number;
+  type?: string;
+}

--- a/unified-codes/libs/data/src/lib/types/Pagination.ts
+++ b/unified-codes/libs/data/src/lib/types/Pagination.ts
@@ -9,25 +9,3 @@ export interface IPaginatedResults<T> {
   hasMore: boolean;
   totalResults: number;
 }
-
-export interface IPaginationRequest {
-  first: number;
-  offset: number;
-}
-export class PaginationRequest implements IPaginationRequest {
-  _first: number;
-  _offset: number;
-
-  constructor(first?: number, offset?: number) {
-    this._first = first || 25;
-    this._offset = offset || 0;
-  }
-
-  get first(): number {
-    return this._first;
-  }
-
-  get offset(): number {
-    return this._offset;
-  }
-}

--- a/unified-codes/libs/data/src/lib/types/index.ts
+++ b/unified-codes/libs/data/src/lib/types/index.ts
@@ -3,6 +3,7 @@ export * from './ApolloService';
 export * from './AuthenticationService';
 export * from './AuthorisationService';
 export * from './Entity';
+export * from './EntitySearch';
 export * from './IdentityProvider';
 export * from './JWT';
 export * from './Pagination';

--- a/unified-codes/libs/data/src/lib/types/index.ts
+++ b/unified-codes/libs/data/src/lib/types/index.ts
@@ -4,6 +4,7 @@ export * from './AuthenticationService';
 export * from './AuthorisationService';
 export * from './Entity';
 export * from './EntitySearch';
+export * from './Explorer';
 export * from './IdentityProvider';
 export * from './JWT';
 export * from './Pagination';

--- a/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
+++ b/unified-codes/libs/ui/src/lib/components/entity/organisms/EntityBrowser.tsx
@@ -6,21 +6,20 @@ import EntityTable from '../molecules/EntityTable';
 import Grid from '../../layout/atoms/Grid';
 import SearchBar from '../../inputs/molecules/SearchBar';
 import TablePagination from '@material-ui/core/TablePagination';
-import { IPaginationRequest, PaginationRequest } from '@unified-codes/data';
+import { EntitySearchFilter, EntitySearchRequest, IEntitySearchRequest } from '@unified-codes/data';
 
 export interface EntityBrowserProps {
   data: IPaginatedResults<Entity>;
   onChange?: (value: string) => void;
   onClear?: () => void;
-  onFetch?: (request: IPaginationRequest) => void;
-  onSearch?: (value: string) => void;
+  onSearch?: (request: IEntitySearchRequest) => void;
 }
 
 export type EntityBrowser = React.FunctionComponent<EntityBrowserProps>;
 type RowsPerPageEvent = React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>;
 type MouseEvent = React.MouseEvent<HTMLButtonElement> | null;
 
-export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch, onSearch }) => {
+export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onSearch }) => {
   const [input, setInput] = React.useState('');
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
@@ -35,36 +34,51 @@ export const EntityBrowser: EntityBrowser = ({ data, onChange, onClear, onFetch,
 
   const handleChangePage = (_: MouseEvent, newPage: number) => {
     setPage(newPage);
-    const request = new PaginationRequest(rowsPerPage, newPage * rowsPerPage);
-    onFetch && onFetch(request);
+    const filter = new EntitySearchFilter(input);
+    const request = new EntitySearchRequest(filter, rowsPerPage, newPage * rowsPerPage);
+    onSearch && onSearch(request);
   };
 
   const handleChangeRowsPerPage = (event: RowsPerPageEvent) => {
     const rowsPerPage = +event.target.value;
     setRowsPerPage(rowsPerPage);
     setPage(0);
-    const request = new PaginationRequest(rowsPerPage);
-    onFetch && onFetch(request);
+    const filter = new EntitySearchFilter(input);
+    const request = new EntitySearchRequest(filter, rowsPerPage);
+    onSearch && onSearch(request);
+  };
+
+  const handleSearch = (value: string) => {
+    const filter = new EntitySearchFilter(value);
+    const request = new EntitySearchRequest(filter, rowsPerPage, page * rowsPerPage);
+    onSearch && onSearch(request);
   };
 
   return (
     <Grid container direction="column">
       <Grid item>
-        <SearchBar input={input} onChange={onChangeInput} onClear={onClear} onSearch={onSearch} />
+        <SearchBar
+          input={input}
+          onChange={onChangeInput}
+          onClear={onClear}
+          onSearch={handleSearch}
+        />
       </Grid>
       <Grid item style={{ maxHeight: 400, overflow: 'scroll' }}>
-        <EntityTable data={data.entities} />
+        {data.totalResults ? <EntityTable data={data.entities} /> : <div>No Results</div>}
       </Grid>
       <Grid item>
-        <TablePagination
-          rowsPerPageOptions={[10, 25, 100]}
-          component="div"
-          count={data.totalResults}
-          rowsPerPage={rowsPerPage}
-          page={page}
-          onChangePage={handleChangePage}
-          onChangeRowsPerPage={handleChangeRowsPerPage}
-        />
+        {data.totalResults && (
+          <TablePagination
+            rowsPerPageOptions={[10, 25, 100]}
+            component="div"
+            count={data.totalResults}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onChangePage={handleChangePage}
+            onChangeRowsPerPage={handleChangeRowsPerPage}
+          />
+        )}
       </Grid>
     </Grid>
   );


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #170 

## Description
This connects the `Explorer` filter function back to dgraph, using the regex syntax.
Ignore the pagination aspects, as that, I think, we'll move out of global state.

The use of a saga to run the search as a side-effect after updating the search parameters is potentially a bit iffy. It cleans up the code though, and I think there's an argument that if the search parameters are updated, then the search results should also be updated?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
