### PR TITLE
#219 Update GraphQL schema to match IEntity type

### DIFF
--- a/unified-codes/apps/data-service/src/app/queries.ts
+++ b/unified-codes/apps/data-service/src/app/queries.ts
@@ -6,8 +6,8 @@ export const queries = {
           description
           type
           value
-          has_child
-          has_property
+          children: has_child
+          properties: has_property
         }
       }`;
   },
@@ -27,8 +27,8 @@ export const queries = {
         type
         uid
         value
-        has_child
-        has_property
+        children: has_child
+        properties: has_property
       }
     }`;
   },

--- a/unified-codes/apps/data-service/src/app/resolvers.ts
+++ b/unified-codes/apps/data-service/src/app/resolvers.ts
@@ -65,7 +65,7 @@ export const resolvers = {
           (properties) => properties.type == 'code_rxnav'
         );
 
-        if (rxNavIds.length) {
+        if (rxNavIds?.length) {
           const rxCui = rxNavIds[0].value;
           const rxNavResponse = await rxNav.getInteractions(rxCui);
           return mappers.mapInteractionResponse(rxNavResponse);

--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -7,14 +7,14 @@ const typeDefs = gql`
     type: String!
     uid: String!
     interactions: [DrugInteraction]
-    has_child: [Entity]
-    has_property: [Property]
+    children: [Entity]
+    properties: [Property]
   }
 
   type Property {
     type: String!
     value: String!
-    has_property: [Property]
+    properties: [Property]
   }
 
   type DrugInteraction {

--- a/unified-codes/apps/web/src/sagas/DetailSaga.ts
+++ b/unified-codes/apps/web/src/sagas/DetailSaga.ts
@@ -42,22 +42,22 @@ const getEntityQuery = (code: string) => `
     code
     description
     type
-    has_property {
+    properties {
       type
       value
     }
     # form_category
-    has_child {
+    children {
       code
       description
       type
       # form
-      has_child {
+      children {
         code
         description
         type
         # unit_of_use
-        has_child {
+        children {
           code
           description
           type


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #219.

## Description
<!--- Briefly describe your changes -->
Small adjustment to GraphQL schema to match our internal `IEntity` type definition. This should make interactions and details work as expected again (and now only Dgraph/data-service should know about the naming `has_child` and `has_property`) 🥳  

Fields renamed:
- has_child -> children
- has_property -> properties 

New sample query format:
```
query GetProductByUC {
  entity (code: "4231441c") {
    code 
    description
    type
    children {
      code
      description
      type
      children {
        code
        description
        type
      }
    }
    properties {
      type
      value
    }
  }
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
