### PR TITLE
connect pagination

### DIFF
--- a/unified-codes/apps/web/src/actions/ExplorerActions.ts
+++ b/unified-codes/apps/web/src/actions/ExplorerActions.ts
@@ -1,247 +1,252 @@
 import { Action } from 'redux';
-
 import { EEntityField, IEntity } from '@unified-codes/data';
+import { IExplorerParameters } from '../types';
 
 export interface IExplorerSearchBarUpdateInputAction extends Action<string> {
-    input: string;
+  input: string;
 }
 
 export interface IExplorerSearchBarUpdateFilterByAction extends Action<string> {
-    filterBy: EEntityField;
+  filterBy: EEntityField;
 }
 
-
 export interface IExplorerTableUpdateRowsPerPageAction extends Action<string> {
-    rowsPerPage: number;
+  rowsPerPage: number;
 }
 
 export interface IExplorerTableUpdatePageAction extends Action<string> {
-    page: number;
+  page: number;
 }
 
 export interface IExplorerTableUpdateOrderByAction extends Action<string> {
-    orderBy: EEntityField;
+  orderBy: EEntityField;
 }
 
 export interface IExplorerTableUpdateOrderDescAction extends Action<string> {
-    orderDesc: boolean;
+  orderDesc: boolean;
 }
 
 export interface IExplorerTableUpdateFilterByAction extends Action<string> {
-    filterBy: string;
+  filterBy: string;
 }
 
-export interface IExplorerTableFetchEntitiesAction extends Action<string> { };
+export interface IExplorerTableFetchEntitiesAction extends Action<string> {
+  parameters?: IExplorerParameters;
+}
 
 export interface IExplorerTableFetchEntitiesSuccessAction extends Action<string> {
-    entities: { data: IEntity[], totalLength: number };
-};
+  entities: { data: IEntity[]; totalLength: number };
+}
 
 export interface IExplorerTableFetchEntitiesFailureAction extends Action<string> {
-    error: Error;
-};
+  error: Error;
+}
 
 export interface IExplorerToggleBarUpdateFilterByDrugAction extends Action<string> {
-    filterByDrug: boolean;
+  filterByDrug: boolean;
 }
 
 export interface IExplorerToggleBarUpdateFilterByUnitOfUseAction extends Action<string> {
-    filterByUnitOfUse: boolean;
+  filterByUnitOfUse: boolean;
 }
 
 export interface IExplorerToggleBarUpdateFilterByOtherAction extends Action<string> {
-    filterByOther: boolean;
+  filterByOther: boolean;
 }
 
-export interface IExplorerToggleBarToggleByDrugAction extends Action<string> { }
+export interface IExplorerToggleBarToggleByDrugAction extends Action<string> {}
 
-export interface IExplorerToggleBarToggleByUnitOfUseAction extends Action<string> { }
+export interface IExplorerToggleBarToggleByUnitOfUseAction extends Action<string> {}
 
-export interface IExplorerToggleBarToggleByOtherAction extends Action<string> { }
+export interface IExplorerToggleBarToggleByOtherAction extends Action<string> {}
 
 export type IExplorerSearchBarAction =
-    IExplorerSearchBarUpdateInputAction |
-    IExplorerSearchBarUpdateFilterByAction;
+  | IExplorerSearchBarUpdateInputAction
+  | IExplorerSearchBarUpdateFilterByAction;
 
 export type IExplorerTableAction =
-    IExplorerTableUpdateRowsPerPageAction |
-    IExplorerTableUpdatePageAction |
-    IExplorerTableUpdateOrderByAction |
-    IExplorerTableUpdateOrderDescAction |
-    IExplorerTableUpdateFilterByAction |
-    IExplorerTableFetchEntitiesAction |
-    IExplorerTableFetchEntitiesSuccessAction |
-    IExplorerTableFetchEntitiesFailureAction;
+  | IExplorerTableUpdateRowsPerPageAction
+  | IExplorerTableUpdatePageAction
+  | IExplorerTableUpdateOrderByAction
+  | IExplorerTableUpdateOrderDescAction
+  | IExplorerTableUpdateFilterByAction
+  | IExplorerTableFetchEntitiesAction
+  | IExplorerTableFetchEntitiesSuccessAction
+  | IExplorerTableFetchEntitiesFailureAction;
 
 export type IExplorerToggleBarAction =
-    IExplorerToggleBarUpdateFilterByDrugAction |
-    IExplorerToggleBarUpdateFilterByUnitOfUseAction |
-    IExplorerToggleBarUpdateFilterByOtherAction |
-    IExplorerToggleBarToggleByDrugAction |
-    IExplorerToggleBarToggleByUnitOfUseAction |
-    IExplorerToggleBarToggleByOtherAction;
+  | IExplorerToggleBarUpdateFilterByDrugAction
+  | IExplorerToggleBarUpdateFilterByUnitOfUseAction
+  | IExplorerToggleBarUpdateFilterByOtherAction
+  | IExplorerToggleBarToggleByDrugAction
+  | IExplorerToggleBarToggleByUnitOfUseAction
+  | IExplorerToggleBarToggleByOtherAction;
 
-export type IExplorerAction = IExplorerSearchBarAction | IExplorerTableAction | IExplorerToggleBarAction;
+export type IExplorerAction =
+  | IExplorerSearchBarAction
+  | IExplorerTableAction
+  | IExplorerToggleBarAction;
 
 export const EXPLORER_SEARCH_BAR_ACTIONS = {
-    UPDATE_INPUT: 'explorer/searchBar/updateInput',
-    UPDATE_FILTER_BY: 'explorer/searchBar/updateFilterBy',
-    RESET_INPUT: 'explorer/searchBar/resetInput',
-    RESET_FILTER_BY: 'explorer/searchBar/resetFilterBy', 
+  UPDATE_INPUT: 'explorer/searchBar/updateInput',
+  UPDATE_FILTER_BY: 'explorer/searchBar/updateFilterBy',
+  RESET_INPUT: 'explorer/searchBar/resetInput',
+  RESET_FILTER_BY: 'explorer/searchBar/resetFilterBy',
 };
 
 export const EXPLORER_TABLE_ACTIONS = {
-    UPDATE_ENTITIES: 'explorer/table/updateEntities',
-    UPDATE_ENTITIES_SUCCESS: 'explorer/table/updateEntitiesSuccess',
-    UPDATE_ENTITIES_FAILURE: 'explorer/table/updateEntitiesFailure', 
-    UPDATE_ORDER_BY: 'explorer/table/updateOrderBy',
-    UPDATE_ORDER_DESC: 'explorer/table/updateOrderDesc',
-    UPDATE_ROWS_PER_PAGE: 'explorer/table/updateRowsPerPage',
-    UPDATE_PAGE: 'explorer/table/updatePage',
-    RESET_ENTITIES: 'explorer/table/resetEntities',
-    RESET_ORDER_BY: 'explorer/table/resetOrderBy',
-    RESET_ORDER_DESC: 'explorer/table/resetOrderDesc',
-    RESET_ROWS_PER_PAGE: 'explorer/table/resetRowsPerPage',
-    RESET_PAGE: 'explorer/table/resetPage',
+  UPDATE_ENTITIES: 'explorer/table/updateEntities',
+  UPDATE_ENTITIES_SUCCESS: 'explorer/table/updateEntitiesSuccess',
+  UPDATE_ENTITIES_FAILURE: 'explorer/table/updateEntitiesFailure',
+  UPDATE_ORDER_BY: 'explorer/table/updateOrderBy',
+  UPDATE_ORDER_DESC: 'explorer/table/updateOrderDesc',
+  UPDATE_ROWS_PER_PAGE: 'explorer/table/updateRowsPerPage',
+  UPDATE_PAGE: 'explorer/table/updatePage',
+  RESET_ENTITIES: 'explorer/table/resetEntities',
+  RESET_ORDER_BY: 'explorer/table/resetOrderBy',
+  RESET_ORDER_DESC: 'explorer/table/resetOrderDesc',
+  RESET_ROWS_PER_PAGE: 'explorer/table/resetRowsPerPage',
+  RESET_PAGE: 'explorer/table/resetPage',
 };
 
 export const EXPLORER_TOGGLE_BAR_ACTIONS = {
-    UPDATE_FILTER_BY_DRUG: 'explorer/toggleBar/updateFilterByDrug',
-    UPDATE_FILTER_BY_MEDICINAL_PRODUCT: 'explorer/toggleBar/updateFilterByUnitOfUse',
-    UPDATE_FILTER_BY_OTHER: 'explorer/toggleBar/updateFilterByOther',
-    TOGGLE_FILTER_BY_DRUG: 'explorer/toggleBar/toggleFilterByDrug',
-    TOGGLE_FILTER_BY_MEDICINAL_PRODUCT: 'explorer/toggleBar/toggleFilterByMedicinalProduct',
-    TOGGLE_FILTER_BY_OTHER: 'explorer/toggleBar/toggleFilterByOther',
+  UPDATE_FILTER_BY_DRUG: 'explorer/toggleBar/updateFilterByDrug',
+  UPDATE_FILTER_BY_MEDICINAL_PRODUCT: 'explorer/toggleBar/updateFilterByUnitOfUse',
+  UPDATE_FILTER_BY_OTHER: 'explorer/toggleBar/updateFilterByOther',
+  TOGGLE_FILTER_BY_DRUG: 'explorer/toggleBar/toggleFilterByDrug',
+  TOGGLE_FILTER_BY_MEDICINAL_PRODUCT: 'explorer/toggleBar/toggleFilterByMedicinalProduct',
+  TOGGLE_FILTER_BY_OTHER: 'explorer/toggleBar/toggleFilterByOther',
 };
 
 const updateInput = (input: string) => ({
-    type: EXPLORER_SEARCH_BAR_ACTIONS.UPDATE_INPUT,
-    input,
+  type: EXPLORER_SEARCH_BAR_ACTIONS.UPDATE_INPUT,
+  input,
 });
 
 const updateFilterBy = (filterBy: string) => ({
-    type: EXPLORER_SEARCH_BAR_ACTIONS.UPDATE_FILTER_BY,
-    filterBy,
+  type: EXPLORER_SEARCH_BAR_ACTIONS.UPDATE_FILTER_BY,
+  filterBy,
 });
 
 const resetInput = () => ({
-    type: EXPLORER_SEARCH_BAR_ACTIONS.RESET_INPUT
+  type: EXPLORER_SEARCH_BAR_ACTIONS.RESET_INPUT,
 });
 
 const resetFilterBy = () => ({ type: EXPLORER_SEARCH_BAR_ACTIONS.RESET_FILTER_BY });
 
 const updateRowsPerPage = (rowsPerPage: number) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ROWS_PER_PAGE,
-    rowsPerPage,
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ROWS_PER_PAGE,
+  rowsPerPage,
 });
 
 const updatePage = (page: number) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_PAGE,
-    page,
-})
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_PAGE,
+  page,
+});
 
 const updateOrderBy = (orderBy: EEntityField) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ORDER_BY,
-    orderBy,
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ORDER_BY,
+  orderBy,
 });
 
 const updateOrderDesc = (orderDesc: boolean) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ORDER_DESC,
-    orderDesc,
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ORDER_DESC,
+  orderDesc,
 });
 
-export const updateEntities = () => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES
+export const updateEntities = (parameters?: IExplorerParameters) => ({
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES,
+  parameters,
 });
 
 export const updateEntitiesSuccess = (entities: IEntity[]) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES_SUCCESS,
-    entities,
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES_SUCCESS,
+  entities,
 });
 
 export const updateEntitiesFailure = (error: Error) => ({
-    type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES_FAILURE,
-    error,
+  type: EXPLORER_TABLE_ACTIONS.UPDATE_ENTITIES_FAILURE,
+  error,
 });
 
 const resetEntities = () => ({ type: EXPLORER_TABLE_ACTIONS.RESET_ENTITIES });
 
-const resetOrderBy = () => ({ type:  EXPLORER_TABLE_ACTIONS.RESET_ORDER_BY });
+const resetOrderBy = () => ({ type: EXPLORER_TABLE_ACTIONS.RESET_ORDER_BY });
 
-const resetOrderDesc = () => ({ type:  EXPLORER_TABLE_ACTIONS.RESET_ORDER_DESC });
+const resetOrderDesc = () => ({ type: EXPLORER_TABLE_ACTIONS.RESET_ORDER_DESC });
 
-const resetRowsPerPage = () => ({ type:  EXPLORER_TABLE_ACTIONS.RESET_ROWS_PER_PAGE });
+const resetRowsPerPage = () => ({ type: EXPLORER_TABLE_ACTIONS.RESET_ROWS_PER_PAGE });
 
-const resetPage = () => ({ type:  EXPLORER_TABLE_ACTIONS.RESET_PAGE });
+const resetPage = () => ({ type: EXPLORER_TABLE_ACTIONS.RESET_PAGE });
 
 const updateFilterByDrug = (filterByDrug: boolean) => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_DRUG,
-    filterByDrug,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_DRUG,
+  filterByDrug,
 });
 
 const updateFilterByMedicinalProduct = (filterByMedicinalProduct: boolean) => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_MEDICINAL_PRODUCT,
-    filterByMedicinalProduct,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_MEDICINAL_PRODUCT,
+  filterByMedicinalProduct,
 });
 
 const updateFilterByOther = (filterByOther: boolean) => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_OTHER,
-    filterByOther,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.UPDATE_FILTER_BY_OTHER,
+  filterByOther,
 });
 
 const toggleFilterByDrug = () => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_DRUG,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_DRUG,
 });
 
 const toggleFilterByMedicinalProduct = () => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_MEDICINAL_PRODUCT,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_MEDICINAL_PRODUCT,
 });
 
 const toggleFilterByOther = () => ({
-    type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_OTHER,
+  type: EXPLORER_TOGGLE_BAR_ACTIONS.TOGGLE_FILTER_BY_OTHER,
 });
 
 export const ExplorerSearchBarActions = {
-    updateInput,
-    updateFilterBy,
-    resetInput,
-    resetFilterBy
+  updateInput,
+  updateFilterBy,
+  resetInput,
+  resetFilterBy,
 };
 
 export const ExplorerTableActions = {
-    updateOrderBy,
-    updateOrderDesc,
-    updatePage,
-    updateRowsPerPage,
-    updateEntities,
-    updateEntitiesSuccess,
-    updateEntitiesFailure,
-    resetOrderBy,
-    resetOrderDesc,
-    resetPage,
-    resetRowsPerPage,
-    resetEntities,
+  updateOrderBy,
+  updateOrderDesc,
+  updatePage,
+  updateRowsPerPage,
+  updateEntities,
+  updateEntitiesSuccess,
+  updateEntitiesFailure,
+  resetOrderBy,
+  resetOrderDesc,
+  resetPage,
+  resetRowsPerPage,
+  resetEntities,
 };
 
 export const ExplorerToggleBarActions = {
-    updateFilterByDrug,
-    updateFilterByMedicinalProduct,
-    updateFilterByOther,
-    toggleFilterByDrug,
-    toggleFilterByMedicinalProduct,
-    toggleFilterByOther
+  updateFilterByDrug,
+  updateFilterByMedicinalProduct,
+  updateFilterByOther,
+  toggleFilterByDrug,
+  toggleFilterByMedicinalProduct,
+  toggleFilterByOther,
 };
 
 export const EXPLORER_ACTIONS = {
-    ...EXPLORER_SEARCH_BAR_ACTIONS,
-    ...EXPLORER_TABLE_ACTIONS,
-    ...EXPLORER_TOGGLE_BAR_ACTIONS
-}
+  ...EXPLORER_SEARCH_BAR_ACTIONS,
+  ...EXPLORER_TABLE_ACTIONS,
+  ...EXPLORER_TOGGLE_BAR_ACTIONS,
+};
 
 export const ExplorerActions = {
-    ...ExplorerSearchBarActions,
-    ...ExplorerTableActions,
-    ...ExplorerToggleBarActions,
-}
+  ...ExplorerSearchBarActions,
+  ...ExplorerTableActions,
+  ...ExplorerToggleBarActions,
+};
 
 export default ExplorerActions;

--- a/unified-codes/apps/web/src/components/containers/explorer/ExplorerSearchBar.tsx
+++ b/unified-codes/apps/web/src/components/containers/explorer/ExplorerSearchBar.tsx
@@ -10,31 +10,40 @@ import { IState } from '../../../types';
 import { ITheme } from '../../../styles';
 
 const styles = (_: ITheme) => ({
-    input: { paddingLeft: 15 },
-    button: { marginTop: 15 }
+  input: { paddingLeft: 15 },
+  button: { marginTop: 15 },
 });
 
 const mapDispatchToProps = (dispatch: React.Dispatch<IExplorerAction>) => {
-    const onChange = (input: string) => dispatch(ExplorerActions.updateInput(input));
+  const onChange = (input: string) => dispatch(ExplorerActions.updateInput(input));
 
-    const onClear = () => batch(() => {
-        dispatch(ExplorerActions.resetInput());
-        dispatch(ExplorerActions.resetFilterBy());
-        dispatch(ExplorerActions.updateEntities());
+  const onClear = () =>
+    batch(() => {
+      dispatch(ExplorerActions.resetPage());
+      dispatch(ExplorerActions.resetInput());
+      dispatch(ExplorerActions.resetFilterBy());
+      dispatch(ExplorerActions.updateEntities());
     });
 
-    const onSearch = () => dispatch(ExplorerActions.updateEntities());
+  const onSearch = () =>
+    batch(() => {
+      dispatch(ExplorerActions.resetPage());
+      dispatch(ExplorerActions.updateEntities());
+    });
 
-    return { onChange, onClear, onSearch };
+  return { onChange, onClear, onSearch };
 };
 
 const mapStateToProps = (state: IState) => {
-    const input = ExplorerSelectors.selectInput(state);
-    const label = ExplorerSelectors.selectLabel(state);
-    
-    return { input, label };
+  const input = ExplorerSelectors.selectInput(state);
+  const label = ExplorerSelectors.selectLabel(state);
+
+  return { input, label };
 };
 
-export const ExplorerSearchBar = connect(mapStateToProps, mapDispatchToProps)(withStyles(styles)(SearchBar));
+export const ExplorerSearchBar = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withStyles(styles)(SearchBar));
 
 export default ExplorerSearchBar;

--- a/unified-codes/apps/web/src/components/containers/explorer/ExplorerToggleBar.tsx
+++ b/unified-codes/apps/web/src/components/containers/explorer/ExplorerToggleBar.tsx
@@ -17,25 +17,33 @@ const styles = (_: ITheme) => ({});
 export interface ExplorerToggleBarProps {
   classes?: {
     root?: string;
-  },
-  buttons: React.ReactElement[]
+  };
+  buttons: React.ReactElement[];
 }
 
 export type ExplorerToggleBar = React.FunctionComponent<ExplorerToggleBarProps>;
 
 const ExplorerToggleBarComponent: ExplorerToggleBar = ({ classes, buttons }) => {
-  const toggleButtons = buttons.map(button => <Grid item key={button?.key as React.ReactText}>{button}</Grid>);
+  const toggleButtons = buttons.map((button) => (
+    <Grid item key={button?.key as React.ReactText}>
+      {button}
+    </Grid>
+  ));
 
   return (
     <Grid container classes={classes} justify="center" direction="row" spacing={2}>
       {toggleButtons}
     </Grid>
   );
-}
+};
 
-const mergeProps = ((stateProps: any, dispatchProps: any) => {
+const mergeProps = (stateProps: any, dispatchProps: any) => {
   const { filterByDrug, filterByMedicinalProduct, filterByOther } = stateProps;
-  const { onToggleFilterByDrug, onToggleFilterByMedicinalProduct, onToggleFilterByOther } = dispatchProps;
+  const {
+    onToggleFilterByDrug,
+    onToggleFilterByMedicinalProduct,
+    onToggleFilterByOther,
+  } = dispatchProps;
 
   const drugButtonLabel = 'Drug';
   const drugButtonKey = EEntityType.DRUG;
@@ -46,7 +54,11 @@ const mergeProps = ((stateProps: any, dispatchProps: any) => {
   const medicinalProductButtonLabel = 'Medicinal product';
   const medicinalProductButtonKey = EEntityType.MEDICINAL_PRODUCT;
   const medicinalProductButtonColor = filterByMedicinalProduct ? 'primary' : 'secondary';
-  const medicinalProductButtonStartIcon = filterByMedicinalProduct ? <CheckCircleIcon /> : <AddIcon />;
+  const medicinalProductButtonStartIcon = filterByMedicinalProduct ? (
+    <CheckCircleIcon />
+  ) : (
+    <AddIcon />
+  );
   const medicinalProductButtonOnClick = onToggleFilterByMedicinalProduct;
 
   const otherButtonLabel = 'Other';
@@ -61,7 +73,9 @@ const mergeProps = ((stateProps: any, dispatchProps: any) => {
       startIcon={drugButtonStartIcon}
       color={drugButtonColor}
       onClick={drugButtonOnClick}
-    >{drugButtonLabel}</ExplorerToggleButton>
+    >
+      {drugButtonLabel}
+    </ExplorerToggleButton>
   );
 
   const ToggleButtonMedicinalProduct = (
@@ -70,7 +84,9 @@ const mergeProps = ((stateProps: any, dispatchProps: any) => {
       startIcon={medicinalProductButtonStartIcon}
       color={medicinalProductButtonColor}
       onClick={medicinalProductButtonOnClick}
-    >{medicinalProductButtonLabel}</ExplorerToggleButton>
+    >
+      {medicinalProductButtonLabel}
+    </ExplorerToggleButton>
   );
 
   const ToggleButtonOther = (
@@ -79,27 +95,35 @@ const mergeProps = ((stateProps: any, dispatchProps: any) => {
       startIcon={otherButtonStartIcon}
       color={otherButtonColor}
       onClick={otherButtonOnClick}
-    >{otherButtonLabel}</ExplorerToggleButton>
+    >
+      {otherButtonLabel}
+    </ExplorerToggleButton>
   );
 
   return { buttons: [ToggleButtonDrug, ToggleButtonMedicinalProduct, ToggleButtonOther] };
-})
+};
 
 const mapDispatchToProps = (dispatch: React.Dispatch<IExplorerAction>) => {
-  const onToggleFilterByDrug = () => batch(() => {
-    dispatch(ExplorerActions.toggleFilterByDrug());
-    dispatch(ExplorerActions.updateEntities());
-  });
+  const onToggleFilterByDrug = () =>
+    batch(() => {
+      dispatch(ExplorerActions.resetPage());
+      dispatch(ExplorerActions.toggleFilterByDrug());
+      dispatch(ExplorerActions.updateEntities());
+    });
 
-  const onToggleFilterByMedicinalProduct = () => batch(() => {
-    dispatch(ExplorerActions.toggleFilterByMedicinalProduct());
-    dispatch(ExplorerActions.updateEntities())
-  });
+  const onToggleFilterByMedicinalProduct = () =>
+    batch(() => {
+      dispatch(ExplorerActions.resetPage());
+      dispatch(ExplorerActions.toggleFilterByMedicinalProduct());
+      dispatch(ExplorerActions.updateEntities());
+    });
 
-  const onToggleFilterByOther =  () => batch(() => { 
-    dispatch(ExplorerActions.toggleFilterByOther());
-    dispatch(ExplorerActions.updateEntities())
-  });
+  const onToggleFilterByOther = () =>
+    batch(() => {
+      dispatch(ExplorerActions.resetPage());
+      dispatch(ExplorerActions.toggleFilterByOther());
+      dispatch(ExplorerActions.updateEntities());
+    });
 
   return { onToggleFilterByDrug, onToggleFilterByMedicinalProduct, onToggleFilterByOther };
 };
@@ -112,6 +136,10 @@ const mapStateToProps = (state: IState) => {
   return { filterByDrug, filterByMedicinalProduct, filterByOther };
 };
 
-export const ExplorerToggleBar = connect(mapStateToProps, mapDispatchToProps, mergeProps)(withStyles(styles)(ExplorerToggleBarComponent));
+export const ExplorerToggleBar = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(withStyles(styles)(ExplorerToggleBarComponent));
 
 export default ExplorerToggleBar;

--- a/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
+++ b/unified-codes/apps/web/src/reducers/ExplorerReducer.ts
@@ -8,6 +8,8 @@ import {
   IExplorerTableFetchEntitiesSuccessAction,
   IExplorerTableUpdateOrderByAction,
   IExplorerTableUpdateOrderDescAction,
+  IExplorerTableUpdatePageAction,
+  IExplorerTableUpdateRowsPerPageAction,
 } from '../actions';
 
 const initialState: IExplorerState = {
@@ -125,6 +127,16 @@ export const ExplorerReducer = (
         ...state,
         toggleBar: { ...state.toggleBar, [EEntityType.OTHER]: !state.toggleBar[EEntityType.OTHER] },
       };
+    }
+
+    case EXPLORER_ACTIONS.UPDATE_PAGE: {
+      const { page } = action as IExplorerTableUpdatePageAction;
+      return { ...state, table: { ...state.table, page } };
+    }
+
+    case EXPLORER_ACTIONS.UPDATE_ROWS_PER_PAGE: {
+      const { rowsPerPage } = action as IExplorerTableUpdateRowsPerPageAction;
+      return { ...state, table: { ...state.table, rowsPerPage } };
     }
   }
 

--- a/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
+++ b/unified-codes/apps/web/src/sagas/ExplorerSaga.ts
@@ -2,7 +2,13 @@ import { call, put, takeEvery, all, select } from 'redux-saga/effects';
 
 import { AlertSeverity, IAlert, IEntity } from '@unified-codes/data';
 
-import { AlertActions, ExplorerActions, EXPLORER_ACTIONS, IExplorerAction } from '../actions';
+import {
+  AlertActions,
+  ExplorerActions,
+  EXPLORER_ACTIONS,
+  IExplorerAction,
+  IExplorerTableFetchEntitiesAction,
+} from '../actions';
 import { ExplorerSelectors } from '../selectors';
 import { ExplorerQuery, IExplorerParameters } from '../types';
 
@@ -48,33 +54,16 @@ const getEntities = async (url: string, query: ExplorerQuery): Promise<IEntity[]
   return entities;
 };
 
-function* fetchData() {
+function* fetchData(action: IExplorerTableFetchEntitiesAction) {
   yield put(AlertActions.raiseAlert(alertFetch));
   try {
     const url:
       | string
       | undefined = `${process.env.NX_DATA_SERVICE_URL}:${process.env.NX_DATA_SERVICE_PORT}/${process.env.NX_DATA_SERVICE_GRAPHQL}`;
     if (url) {
-      const code = yield select(ExplorerSelectors.selectCode);
-      const description = yield select(ExplorerSelectors.selectDescription);
-      const types = yield select(ExplorerSelectors.selectTypes);
-      const orderBy = yield select(ExplorerSelectors.selectOrderBy);
-      const orderDesc = yield select(ExplorerSelectors.selectOrderDesc);
-      const rowsPerPage = yield select(ExplorerSelectors.selectRowsPerPage);
-      const page = yield select(ExplorerSelectors.selectPage);
-
-      const parameters: IExplorerParameters = {
-        code,
-        description,
-        types,
-        orderBy,
-        orderDesc,
-        rowsPerPage,
-        page,
-      };
-
+      const parameters: IExplorerParameters =
+        action?.parameters || (yield select(ExplorerSelectors.selectParameters));
       const query = new ExplorerQuery(parameters);
-
       const entities = yield call(getEntities, url, query);
 
       yield put(ExplorerActions.updateEntitiesSuccess(entities));

--- a/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
+++ b/unified-codes/apps/web/src/selectors/ExplorerSelectors.ts
@@ -3,6 +3,7 @@ import { createSelector } from 'reselect';
 import { EEntityField, EEntityType, IEntity } from '@unified-codes/data';
 
 import {
+  IExplorerParameters,
   IExplorerSearchBarState,
   IExplorerState,
   IExplorerTableState,
@@ -79,6 +80,39 @@ const selectRowsPerPage = createSelector(
 
 const selectPage = createSelector(selectTable, (table: IExplorerTableState): number => table?.page);
 
+const selectTypes = createSelector(
+  selectToggleBar,
+  (toggleBar: IExplorerToggleBarState): EEntityType[] =>
+    Object.keys(toggleBar).filter((type: EEntityType) => toggleBar[type]) as EEntityType[]
+);
+
+const selectParameters = createSelector(
+  selectCode,
+  selectDescription,
+  selectTypes,
+  selectOrderBy,
+  selectOrderDesc,
+  selectRowsPerPage,
+  selectPage,
+  (
+    code: string,
+    description: string,
+    types: EEntityType[],
+    orderBy: EEntityField,
+    orderDesc: boolean,
+    rowsPerPage: number,
+    page: number
+  ): IExplorerParameters => ({
+    code,
+    description,
+    types,
+    orderBy,
+    orderDesc,
+    rowsPerPage,
+    page,
+  })
+);
+
 const selectEntities = createSelector(
   selectTable,
   (table: IExplorerTableState): IEntity[] => table?.entities
@@ -97,12 +131,6 @@ const selectFilterByMedicinalProduct = createSelector(
 const selectFilterByOther = createSelector(
   selectToggleBar,
   (toggleBar: IExplorerToggleBarState): boolean => toggleBar?.[EEntityType.OTHER]
-);
-
-const selectTypes = createSelector(
-  selectToggleBar,
-  (toggleBar: IExplorerToggleBarState): EEntityType[] =>
-    Object.keys(toggleBar).filter((type: EEntityType) => toggleBar[type]) as EEntityType[]
 );
 
 const selectLoading = createSelector(
@@ -125,6 +153,7 @@ export const TableSelectors = {
   selectOrderBy,
   selectOrderDesc,
   selectPage,
+  selectParameters,
   selectRowsPerPage,
   selectTypes,
 };


### PR DESCRIPTION

Fixes #235 

## Description
Connects pagination controls - have added the ability to pass in parameters when updating entities; this allows updating of params for the search, without needing to chain dispatches or wait for the store to update before fetching.

Other suggestions?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
