### PR TITLE
#268 add the ability to switch between progress indicators

### DIFF
--- a/unified-codes/apps/web/src/components/containers/explorer/ExplorerPage.tsx
+++ b/unified-codes/apps/web/src/components/containers/explorer/ExplorerPage.tsx
@@ -67,7 +67,7 @@ export const ExplorerPageComponent: ExplorerPage = ({
       table={<ExplorerTable />}
       toggleBar={<ExplorerToggleBar />}
       searchBar={<ExplorerSearchBar />}
-      progressBar={<ExplorerProgressBar />}
+      progressBar={<ExplorerProgressBar type="cat" />}
     />
   );
 };

--- a/unified-codes/apps/web/src/components/containers/explorer/ExplorerProgressBar.tsx
+++ b/unified-codes/apps/web/src/components/containers/explorer/ExplorerProgressBar.tsx
@@ -14,25 +14,36 @@ const useStyles = makeStyles((theme: ITheme) =>
   createStyles({
     root: {
       zIndex: theme.zIndex.drawer + 1,
+      backgroundColor: 'rgba(249, 249, 251, 0.9)',
     },
   })
 );
 
+export type ProgressType = 'cat' | 'material-ui' | undefined;
+
 export interface ExplorerProgressBarProps {
   isLoading: boolean;
+  type: ProgressType;
 }
 
 export type ExplorerProgressBar = React.FunctionComponent<ExplorerProgressBarProps>;
 
-export const ExplorerProgressBarComponent: ExplorerProgressBar = ({ isLoading }) => {
-  const classes = useStyles();
+const getProgressIndicator = (type: ProgressType) => {
+  switch (type) {
+    case 'cat':
+      return <ExplorerProgressCat />;
+    default:
+      return <CircularProgress color="inherit" />;
+  }
+};
 
-  // Uncomment to enable cat mode!
-  // return <ExplorerProgressCat />;
+export const ExplorerProgressBarComponent: ExplorerProgressBar = ({ isLoading, type }) => {
+  const classes = useStyles();
+  const progressIndicator = getProgressIndicator(type);
 
   return (
     <Backdrop className={classes.root} open={isLoading}>
-      <CircularProgress color="inherit" />;
+      {progressIndicator}
     </Backdrop>
   );
 };


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #268 ( partly )

## Description
Add the ability to switch between progress indicators. Perhaps should have the sensible progress as the default and this as an easter egg?
Tidy up the backdrop when using the cat progress.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
