### PR TITLE
implement match filter element

### DIFF
--- a/unified-codes/apps/data-service/src/app/schema.ts
+++ b/unified-codes/apps/data-service/src/app/schema.ts
@@ -1,4 +1,4 @@
-import { Field, ID, InputType, Int, ObjectType, registerEnumType } from 'type-graphql';
+import { Field, ID, InputType, Int, ObjectType /*, registerEnumType */ } from 'type-graphql';
 
 import {
   IEntity,
@@ -7,8 +7,8 @@ import {
   IProperty,
   IEntityCollection,
   IEntitySearch,
-  EEntityField,
-  EEntityType,
+  // EEntityField,
+  // EEntityType,
 } from '@unified-codes/data';
 
 // registerEnumType(EEntityType, {
@@ -18,6 +18,7 @@ import {
 // registerEnumType(EEntityField, {
 //   name: "EEntityField",
 // });
+export type FilterMatch = 'begin' | 'contains' | 'exact' | undefined;
 
 @ObjectType()
 export class EntityType implements IEntity {
@@ -65,6 +66,9 @@ export class EntitySearchInput implements Omit<IEntitySearch, 'type'> {
 
   @Field((type) => String, { nullable: true })
   type: string;
+
+  @Field((type) => String, { nullable: true })
+  match: FilterMatch;
 }
 
 @InputType()

--- a/unified-codes/apps/data-service/src/app/types/DgraphDataSource.ts
+++ b/unified-codes/apps/data-service/src/app/types/DgraphDataSource.ts
@@ -7,6 +7,7 @@ import {
   IEntity,
   IEntityCollection,
 } from '@unified-codes/data';
+import { EntitySearchInput, FilterMatch } from '../schema';
 
 export class DgraphDataSource extends RESTDataSource {
   private static headers: { [key: string]: string } = {
@@ -29,12 +30,34 @@ export class DgraphDataSource extends RESTDataSource {
       }
     }`;
   }
+  private static getEntitiesFilterString(description: string, match: FilterMatch) {
+    if (!description) {
+      return '@filter(has(description))';
+    }
 
-  private static getEntitiesQuery(type, description, orderField, orderDesc, first, offset) {
+    switch (match) {
+      case 'exact':
+        return `@filter(regexp(description, /^${description}$/i))`;
+
+      case 'contains':
+        return `@filter(regexp(description, /${description}/i))`;
+
+      default:
+        return `@filter(regexp(description, /^${description}/i))`;
+    }
+  }
+
+  private static getEntitiesQuery(
+    type: string,
+    description?: string,
+    orderField?: string,
+    orderDesc?: boolean,
+    first?: number,
+    offset?: number,
+    match?: FilterMatch
+  ) {
     const orderString = `${orderDesc ? 'orderdesc' : 'orderasc'}: ${orderField}`;
-    const filterString = description
-      ? `@filter(regexp(description, /.*${description}.*/i))`
-      : '@filter(has(description))';
+    const filterString = this.getEntitiesFilterString(description, match);
 
     return `{
       all as counters(func: anyofterms(type, "${type}")) ${filterString} { 
@@ -72,19 +95,43 @@ export class DgraphDataSource extends RESTDataSource {
     return entity;
   }
 
-  async getEntities(filter, first, offset): Promise<IEntityCollection> {
-    const { type = EEntityType.DRUG, description, orderBy } = filter ?? {};
+  async getEntities(
+    filter?: EntitySearchInput,
+    first?: number,
+    offset?: number
+  ): Promise<IEntityCollection> {
+    const { type = EEntityType.DRUG, description, match, orderBy } = filter ?? {};
     const { field: orderField = EEntityField.DESCRIPTION, descending: orderDesc = true } =
       orderBy ?? {};
 
+    console.warn(
+      'query: ',
+      DgraphDataSource.getEntitiesQuery(
+        type,
+        description,
+        orderField,
+        orderDesc,
+        first,
+        offset,
+        match
+      )
+    );
     const data = await this.postQuery(
-      DgraphDataSource.getEntitiesQuery(type, description, orderField, orderDesc, first, offset)
+      DgraphDataSource.getEntitiesQuery(
+        type,
+        description,
+        orderField,
+        orderDesc,
+        first,
+        offset,
+        match
+      )
     );
 
     const { counters: countersData, query: entityData } = data ?? {};
     const [counterData] = countersData;
     const totalCount = counterData?.total;
-    
+
     // Overwrite interactions to prevent large query delays.
     const entities: IEntity[] =
       entityData?.map((entity: IEntity) => ({ ...entity, interactions: [] })) ?? [];


### PR DESCRIPTION

Fixes #259 

## Description
Implement a `match` parameter on the `filter` property.
This optional value can be `exact | begins (default) | contains`

Can be tested using postman

```
{ "query": "{ entities(filter: { code: \"\" description: \"Dia\" type: \"[drug]\" match: \"contains\" }  offset: 0 first: 25) { data { code description type uid }, totalLength, }}"}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [ ] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [ ] Tests OK.
