### PR TITLE
#387 expand product tree by default

### DIFF
--- a/unified-codes/apps/web/src/components/containers/detail/DetailEntityList.tsx
+++ b/unified-codes/apps/web/src/components/containers/detail/DetailEntityList.tsx
@@ -58,7 +58,7 @@ export type DetailEntityList = React.FunctionComponent<DetailEntityListProps>;
 export const DetailEntityListComponent: DetailEntityList = ({ description, parent, entities }) => {
   const classes = useStyles();
 
-  const { isOpen, onToggle } = useToggle(false);
+  const { isOpen, onToggle } = useToggle(true);
 
   const entityCount = entities.length;
 

--- a/unified-codes/apps/web/src/components/containers/detail/DetailEntityListItem.tsx
+++ b/unified-codes/apps/web/src/components/containers/detail/DetailEntityListItem.tsx
@@ -46,6 +46,10 @@ const useStyles = makeStyles((theme: ITheme) =>
     listItemText: {
       margin: '1px 0px 1px 0px',
     },
+    listItemTextChild: {
+      margin: '1px 0px 1px 0px',
+      fontWeight: 'bold'
+    },
     root: {
       margin: '0px 0px 0px 0px',
       padding: '0px 0px 0px 0px',
@@ -66,7 +70,7 @@ export type DetailEntityListItem = React.FunctionComponent<DetailEntityListItemP
 const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, onCopy }) => {
   const classes = useStyles();
 
-  const { isOpen, onToggle } = useToggle(false);
+  const { isOpen, onToggle } = useToggle(true);
 
   const { code, description, children = [], properties = [] } = entity;
 
@@ -75,7 +79,13 @@ const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, o
   const propertyCount = React.useMemo(() => properties?.length ?? 0, [properties]);
 
   const EntityListItemText = () => (
-    <ListItemText className={classes.listItemText} primary={description} secondary={code} />
+    <ListItemText
+      classes={
+        childCount ? { root:classes.listItemText } : { primary: classes.listItemTextChild, secondary: classes.listItemTextChild }
+      }
+      primary={description}
+      secondary={code}
+    />
   );
 
   const EntityListItemToggleButton = () => {

--- a/unified-codes/apps/web/src/components/containers/detail/DetailEntityListItem.tsx
+++ b/unified-codes/apps/web/src/components/containers/detail/DetailEntityListItem.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme: ITheme) =>
     },
     listItemTextChild: {
       margin: '1px 0px 1px 0px',
-      fontWeight: 'bold'
+      fontWeight: 'bold',
     },
     root: {
       margin: '0px 0px 0px 0px',
@@ -81,7 +81,9 @@ const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, o
   const EntityListItemText = () => (
     <ListItemText
       classes={
-        childCount ? { root:classes.listItemText } : { primary: classes.listItemTextChild, secondary: classes.listItemTextChild }
+        childCount
+          ? { root: classes.listItemText }
+          : { primary: classes.listItemTextChild, secondary: classes.listItemTextChild }
       }
       primary={description}
       secondary={code}
@@ -89,24 +91,37 @@ const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, o
   );
 
   const EntityListItemToggleButton = () => {
-    const onClick = (e) => { onToggle(); e.stopPropagation(); }
-    const ListButton = () => !!childCount || !!propertyCount ? 
-      <ToggleIconButton classes={{ root: classes.button }} isOpen={isOpen} onClick={onClick}/> :
-      <IconButton/>
+    const onClick = (e) => {
+      onToggle();
+      e.stopPropagation();
+    };
+    const ListButton = () =>
+      !!childCount || !!propertyCount ? (
+        <ToggleIconButton classes={{ root: classes.button }} isOpen={isOpen} onClick={onClick} />
+      ) : (
+        <IconButton />
+      );
 
-    return <ListItemIcon><ListButton/></ListItemIcon>;
+    return (
+      <ListItemIcon>
+        <ListButton />
+      </ListItemIcon>
+    );
   };
 
   const EntityListItemCopyButton = () => {
-    const onClick = (e) => { onCopy(code); e.stopPropagation(); }
-    return <CopyIconButton classes={{ root: classes.button}} onClick={onClick}/>
-  }
+    const onClick = (e) => {
+      onCopy(code);
+      e.stopPropagation();
+    };
+    return <CopyIconButton classes={{ root: classes.button }} onClick={onClick} />;
+  };
 
   const EntityListItem = () => (
     <ListItem className={classes.listItem}>
       <EntityListItemToggleButton />
       <EntityListItemText />
-      <EntityListItemCopyButton/>
+      <EntityListItemCopyButton />
     </ListItem>
   );
 
@@ -118,7 +133,7 @@ const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, o
 
   const EntityChildList = () => {
     if (!childCount) return null;
-    return <DetailEntityTypeList parent={entity} entities={children}/>
+    return <DetailEntityTypeList parent={entity} entities={children} />;
   };
 
   return (
@@ -128,7 +143,7 @@ const DetailEntityListItemComponent: DetailEntityListItem = ({ parent, entity, o
         <Collapse in={isOpen}>
           <List className={classes.list}>
             <ListItem className={classes.listItem}>
-              <EntityChildList/>
+              <EntityChildList />
             </ListItem>
             <ListItem className={classes.listItem}>
               <PropertyChildList />


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #387

## Description
<!--- Briefly describe your changes -->
- Expand entity tree by default to make it easier for users to see all available codes for a particular product.
- **Bold** the description and code for child-most items to make it clearer which items are able to be dispensed. 
  - Not convinced it's super clear, but we couldn't really think of a better idea (icons would probably be even more confusing, and removing the copy icon for higher-level codes seems a bit mean since some people might want the higher codes for other use cases that aren't mSupply?)
- Ran prettier over the changed file (soz I probably just made it harder to review 😞 )  

![image](https://user-images.githubusercontent.com/65875762/119078524-79dffa00-ba4a-11eb-8089-7be704c00288.png)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

### Documentation:

Tick below if one of the following applies:

1. Documentation has been added to cover changes introduced by this PR.
2. This PR requires no changes to documentation.

- [x] Documentation OK.

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [x] Tests OK.
