### PR TITLE
remove link to barcodes list for unauthenticated users

### DIFF
--- a/frontend/host/src/components/AppBar/AppBar.tsx
+++ b/frontend/host/src/components/AppBar/AppBar.tsx
@@ -82,15 +82,6 @@ const NavLinks = () => {
       </Link>
       |
       <Link
-        to={RouteBuilder.create(AppRoute.Browse)
-          .addPart(AppRoute.Barcodes)
-          .build()}
-        style={{ color: 'black' }}
-      >
-        {t('label.barcodes')}
-      </Link>
-      |
-      <Link
         to={RouteBuilder.create(AppRoute.About).build()}
         style={{ color: 'black' }}
       >


### PR DESCRIPTION
Removes the link to the barcodes UI from the nav links in the top right for unauthenticated users.

Seeing as barcodes were more-so added as a proof of concept and may not be fleshed out for a while, it's probably best we don't show a link to an empty list just yet. 

As you can see below, unauthenticated users can still access the /browse/barcodes path, they'll just need to type it into the URL.

<img width="991" alt="Screenshot 2024-02-05 at 9 18 09 AM" src="https://github.com/msupply-foundation/unified-codes/assets/55115239/47422057-6e86-4a8c-be2e-01ed0990fe86">
