### PR TITLE
584 include reference in drug interaction query

### DIFF
--- a/backend/dgraph/src/drug_interaction/interactions.rs
+++ b/backend/dgraph/src/drug_interaction/interactions.rs
@@ -23,6 +23,7 @@ query drugInteractions($name: String) {
     description
     action
     severity
+    reference
     drugs {
         name
         description
@@ -58,6 +59,7 @@ query drugInteractions {
     description
     action
     severity
+    reference
     drugs {
         name
         description


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #584

## Description
<!--- Briefly describe your changes -->

Includes reference in the dgraph query so we see the results of what we saved 😁 

https://github.com/msupply-foundation/unified-codes/assets/55115239/1a30f452-5561-4bd4-b84d-7d1e5f01260f


## Note

We've had a few of these issues (or at least I've bumped up against them devving...) especially when adding new fields to existing types, there being no type warning between the DGraph queries and the resulting rust struct... wonder if there is anything we could do for this going forward?