### PR TITLE
Add properties to entities query

### DIFF
--- a/backend/dgraph/src/entities.rs
+++ b/backend/dgraph/src/entities.rs
@@ -60,6 +60,12 @@ query EntitiesQuery($filter: EntityFilter, $first: Int, $offset: Int, $order: En
     code
     alternative_names
     __typename
+    properties {
+        __typename
+        code
+        type
+        value
+    }
     parents {
         id
         name
@@ -125,6 +131,7 @@ mod tests {
         assert_eq!(data.data[0].description, "Heparin Sodium");
         assert_eq!(data.data[0].r#type, "Product");
         assert_eq!(data.aggregates.unwrap().count, 1);
+        assert!(!data.properties.is_empty())
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #605 

## Description
The dgraph backend `entities` query was deliberately kept minimal to avoid having huge dgraph requests just to get product names, however the mSupply query is asking for properties.


```
query{
	entities(filter: { description: "para" type: "drug unit_of_use medicinal_product" orderBy: { field: "description" descending: false } } offset: 0 first: 25) { data { code description type properties { type value } product { properties { type value } } }, totalLength }
}
```

Now returns:

```
{
  "data": {
    "entities": {
      "data": [
        {
          "code": "bbfcf518",
          "description": "Paracetamol Oral Suspension 24mg per mL",
          "type": "DoseStrength",
          "properties": [],
          "product": null
        },
```

## Checklist:
-[ ] Also need to make product properties work, as they should be included in mSupply too...

### Tests:

Tick below if one of the following applies:

1. Tests have been added to cover changes introduced by this PR.
2. This PR requires no new tests.

- [x] Tests OK.
