### PR TITLE
POC: cargo watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ android/app/src/main/jniLibs
 android/.idea
 /build/*
 !/build/.npmkeep
+
+.trigger

--- a/backend/Makefile.toml
+++ b/backend/Makefile.toml
@@ -1,0 +1,10 @@
+[tasks.watch_build]
+script = "cargo watch -x build -s 'touch .trigger'"
+
+[tasks.trigger_server_start]
+# TODO dynamic port?????
+script = "systemfd --no-pid -s http::4007 -- cargo watch --no-vcs-ignores -w .trigger -x run"
+
+[tasks.watch]
+workspace = false
+run_task = { name = ["watch_build", "trigger_server_start"], parallel = true }

--- a/backend/Makefile.toml
+++ b/backend/Makefile.toml
@@ -8,3 +8,13 @@ script = "systemfd --no-pid -s http::4007 -- cargo watch --no-vcs-ignores -w .tr
 [tasks.watch]
 workspace = false
 run_task = { name = ["watch_build", "trigger_server_start"], parallel = true }
+
+[tasks.trigger_server_start_with_downtime]
+script = "cargo watch --no-vcs-ignores -w .trigger -x run"
+
+[tasks.watch_with_downtime]
+workspace = false
+run_task = { name = [
+  "watch_build",
+  "trigger_server_start_with_downtime",
+], parallel = true }

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -23,10 +23,26 @@ extended-description = "Universal Codes Server"
 section = "admin"
 priority = "optional"
 assets = [
-    ["target/release/universal_codes", "/opt/universal_codes/universal_codes", "755"],
-    ["debian/universal_codes.service", "/lib/systemd/system/universal_codes.service", "644"],
-    ["../configuration/base.yaml", "/opt/universal_codes/configuration/", "755"],
-    ["../configuration/example.yaml", "/opt/universal_codes/configuration/", "755"],
+    [
+        "target/release/universal_codes",
+        "/opt/universal_codes/universal_codes",
+        "755",
+    ],
+    [
+        "debian/universal_codes.service",
+        "/lib/systemd/system/universal_codes.service",
+        "644",
+    ],
+    [
+        "../configuration/base.yaml",
+        "/opt/universal_codes/configuration/",
+        "755",
+    ],
+    [
+        "../configuration/example.yaml",
+        "/opt/universal_codes/configuration/",
+        "755",
+    ],
 ]
 maintainer-scripts = "debian/scripts"
 
@@ -35,22 +51,23 @@ graphql = { path = "../graphql" }
 graphql_v1 = { path = "../graphql_v1" }
 graphql_core = { path = "../graphql/core" }
 graphql_types = { path = "../graphql/types" }
-dgraph = {path = "../dgraph"}
+dgraph = { path = "../dgraph" }
 repository = { path = "../repository" }
 service = { path = "../service" }
 util = { path = "../util" }
 
 actix-cors = "0.6.1"
-actix-web = { version= "4.0.1" } 
-actix-http ="3.3.1"
+actix-web = { version = "4.0.1" }
+actix-http = "3.3.1"
 config = "0.13"
 log = "0.4.14"
 serde = "1.0.137"
-tokio = { version = "1.29", features = ["macros" ] }
+tokio = { version = "1.29", features = ["macros"] }
 rust-embed = "6.4.2"
 mime_guess = "2.0.4"
 futures-util = "0.3"
 simple-log = { version = "1.6" }
+listenfd = "1.0.1"
 
 
 [dev-dependencies]

--- a/backend/server/src/lib.rs
+++ b/backend/server/src/lib.rs
@@ -8,6 +8,7 @@ use graphql_core::loader::{get_loaders, LoaderRegistry};
 
 use graphql::config as graphql_config;
 use graphql_v1::config as graphql_v1_config;
+use listenfd::ListenFd;
 use log::{error, info};
 use middleware::{add_authentication_context, limit_content_length};
 use repository::{get_storage_connection_manager, run_db_migrations, StorageConnectionManager};
@@ -155,7 +156,13 @@ async fn run_server(
     })
     .disable_signals();
 
-    http_server = http_server.bind(config_settings.server.address())?;
+    let mut listenfd = ListenFd::from_env();
+
+    http_server = if let Some(listener) = listenfd.take_tcp_listener(0)? {
+        http_server.listen(listener)?
+    } else {
+        http_server.bind(config_settings.server.address())?
+    };
 
     let running_sever = http_server.run();
     let server_handle = running_sever.handle();

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "load-data": "lerna run --scope @universal-codes/data-loader start --stream && yarn update-dgraph-schema",
     "start-backend": "cd backend && cargo run",
-    "start-backend:watch": "cd backend && systemfd --no-pid -s http::4007 -- cargo watch -x run",
+    "start-backend:watch": "cd backend && cargo make watch",
     "build-data-loader": "lerna run --scope @universal-codes/data-loader build",
     "start-frontend": "lerna run --scope @uc-frontend/* --parallel start",
     "build-frontend": "lerna run --scope @uc-frontend/* build",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "load-data": "lerna run --scope @universal-codes/data-loader start --stream && yarn update-dgraph-schema",
     "start-backend": "cd backend && cargo run",
+    "start-backend:watch": "cd backend && systemfd --no-pid -s http::4007 -- cargo watch -x run",
     "build-data-loader": "lerna run --scope @universal-codes/data-loader build",
     "start-frontend": "lerna run --scope @uc-frontend/* --parallel start",
     "build-frontend": "lerna run --scope @uc-frontend/* build",


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->

## POC: using `cargo watch` to restart the development server on changes!

**[RnD Card](https://trello.com/c/EZlKX1FW/62-run-local-development-rust-server-in-watch-mode)**


You'll need to install `cargo-make`, `cargo-watch` and _(maybe: see below)_ `systemfd` globally:

```
cargo install cargo-make cargo-watch systemfd
```
> Note: I'd hoped we could add these to the backend `Cargo.toml` - I think it's nicer when everything comes set up for you when you clone, rather than another setup step with the global install. However, I can't figure out how to do this, as the backend `Cargo.toml` is a virtual manifest, which can't have dependencies?

To now start the backend in watch mode, from the `backend` dir:

```
cargo make watch
```

Or, from the repo root:

```
yarn start-backend:watch
```

This starts two process in parallel:
- `watch_build` watches for any changes in our Rust source code, and executes `cargo build`. When the build is finished (and it compiled correctly), it creates a `.trigger` file.
- `trigger_server_start` watches for changes on this `.trigger` file, and restarts the server. This means the current version of the API remains available until the new version is compiled, and the restart after trigger is fairly quick.

About the packages:
- `cargo-make`: manages the scripts
- `cargo-watch`: watches for file changes, and executes provided commands
- `systemfd`: opens sockets and passes them to another process, allowing that process to restart itself without dropping connections
  - `cargo-watch` stops the existing server before starting the new version. There's a couple seconds of downtime, and we can get dropped requests in that time.
  - `systemfd` spawns a socket that our Rust server can then bind to, meaning we avoid the request-dropping. It keeps the endpoint alive until the new server is ready... i.e. the request hangs for the restart time, rather than returning and error.
  - In order to support this, there is a code change in the server startup code to check for a tcp listener, and listen on this if available. Otherwise, it resorts to binding to the pre-defined port as we had before.
  - **Feedback wanted here!** Because we're not restarting the server until it's already compiled, the gains of this change are fairly minimal... I mean its nice and seamless, but how much do we care if we get an `Error: Couldn't connect to server` for a second or two?
  - I've also left a `cargo make watch_with_downtime` (not using the `systemfd` stuff) so please try this out and let me know your thoughts!
  - If we do go the `systemfd` way, I also need to figure out how to get the port from the configuration into the makefile? Have hardcoded 4007 for now...
