### PR TITLE
Remove parallel upserts for child entities

### DIFF
--- a/backend/dgraph/src/client.rs
+++ b/backend/dgraph/src/client.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 // Seems to mostly happen in tests, but in case this happens in production we'll retry a few times
 // Sounds like this could possibly be to do with updating the same index?
 const DEFAULT_RETRIES: usize = 3;
-const DEFAULT_RETRY_DELAY: u64 = 10;
+const DEFAULT_RETRY_DELAY: u64 = 20;
 
 #[derive(Clone)]
 pub struct DgraphClient {


### PR DESCRIPTION
<!--- Include the issue number in the title -->
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Append issue number here, this is not optional! -->
Fixes #616 

## Description
Discovered that parallel child node inserts seems to trigger dgraph transaction errors.
For some reason this was not seen with earlier inserts...

I've increased the retry time to 20ms, so hopefully increases the chances for the dgraph system to recover before retries kick in.

### Tests:
- [X] No new tests required

I've tested adding Diclofenac as well as editing it.
I'm slightly concerned there was a reason I did children first, before parent but seems to work fine in this order...